### PR TITLE
Blockshape

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,8 @@
 cmake_minimum_required(VERSION 2.8.10)
 
 project(caterva)
+set(GCC_COVERAGE_COMPILE_FLAGS "-Wall")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${GCC_COVERAGE_COMPILE_FLAGS}" )
 
 option(SHARED_LIB "Create shared library" ON)
 option(STATIC_LIB "Create static library" ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,11 +7,12 @@
 # in the COPYING file in the root directory of this source tree).
 # You may select, at your option, one of the above-listed licenses.
 
-cmake_minimum_required(VERSION 3.12)
+# cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.5.1)
 
 
 cmake_policy(SET CMP0048 NEW)
-cmake_policy(SET CMP0077 NEW)
+# cmake_policy(SET CMP0077 NEW)
 
 project(caterva VERSION 0.3.3)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ cmake_minimum_required(VERSION 3.12)
 
 
 cmake_policy(SET CMP0048 NEW)
-# cmake_policy(SET CMP0077 NEW)
+cmake_policy(SET CMP0077 NEW)
 
 project(caterva VERSION 0.3.3)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,8 +7,7 @@
 # in the COPYING file in the root directory of this source tree).
 # You may select, at your option, one of the above-listed licenses.
 
-# cmake_minimum_required(VERSION 3.12)
-cmake_minimum_required(VERSION 3.5.1)
+cmake_minimum_required(VERSION 3.12)
 
 
 cmake_policy(SET CMP0048 NEW)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -89,7 +89,6 @@ steps:
       cd build/
       cmake -DBLOSC_DIR=${BLOSC_DIR} -DBLOSC_INCLUDE=${BLOSC_INCLUDE} ..
       cmake --build . --config ${BUILD_CONFIGURATION}
-      ls -lR
     condition: eq( variables['Agent.OS'], 'Windows_NT' )
     displayName: 'Build caterva'
 

--- a/caterva/caterva.c
+++ b/caterva/caterva.c
@@ -140,6 +140,9 @@ int caterva_array_append(caterva_context_t *ctx, caterva_array_t *array, void *c
             CATERVA_ERROR(caterva_blosc_array_append(ctx, array, chunk, chunksize));
             break;
         case CATERVA_STORAGE_PLAINBUFFER:
+            if (chunksize != array->chunksize * array->itemsize) {
+                CATERVA_ERROR(CATERVA_ERR_INVALID_ARGUMENT);
+            }
             CATERVA_ERROR(caterva_plainbuffer_array_append(ctx, array, chunk, chunksize));
             break;
         default:

--- a/caterva/caterva.c
+++ b/caterva/caterva.c
@@ -150,7 +150,7 @@ int caterva_array_append(caterva_context_t *ctx, caterva_array_t *array, void *c
     }
 
     array->nparts++;
-    if (array->nparts == array->extendedsize / array->chunksize) {
+    if (array->nparts == array->extsize / array->chunksize) {
         array->filled = true;
     }
 

--- a/caterva/caterva.c
+++ b/caterva/caterva.c
@@ -126,14 +126,14 @@ int caterva_array_append(caterva_context_t *ctx, caterva_array_t *array, void *c
     CATERVA_ERROR_NULL(array);
     CATERVA_ERROR_NULL(chunk);
 
-    if (chunksize != array->next_chunksize * array->itemsize) {
-        CATERVA_ERROR(CATERVA_ERR_INVALID_ARGUMENT);
-    }
     if (array->filled) {
         CATERVA_ERROR(CATERVA_ERR_CONTAINER_FILLED);
     }
     switch (array->storage) {
         case CATERVA_STORAGE_BLOSC:
+            if (chunksize != array->next_chunksize * array->itemsize) {
+                CATERVA_ERROR(CATERVA_ERR_INVALID_ARGUMENT);
+            }
             CATERVA_ERROR(caterva_blosc_array_append(ctx, array, chunk, chunksize));
             break;
         case CATERVA_STORAGE_PLAINBUFFER:

--- a/caterva/caterva.c
+++ b/caterva/caterva.c
@@ -78,6 +78,7 @@ int caterva_array_from_frame(caterva_context_t *ctx, blosc2_frame *frame, bool c
         DEBUG_PRINT("Error creating a caterva container from a frame");
         return CATERVA_ERR_NULL_POINTER;
     }
+    (*array)->empty = false;
     return CATERVA_SUCCEED;
 }
 
@@ -110,9 +111,11 @@ int caterva_array_free(caterva_context_t *ctx, caterva_array_t **array) {
 
     if (*array) {
         switch ((*array)->storage) {
-            case CATERVA_STORAGE_BLOSC:caterva_blosc_array_free(ctx, array);
+            case CATERVA_STORAGE_BLOSC:
+                caterva_blosc_array_free(ctx, array);
                 break;
-            case CATERVA_STORAGE_PLAINBUFFER:caterva_plainbuffer_array_free(ctx, array);
+            case CATERVA_STORAGE_PLAINBUFFER:
+                caterva_plainbuffer_array_free(ctx, array);
                 break;
         }
         ctx->cfg->free(*array);
@@ -303,6 +306,8 @@ int caterva_array_get_slice(caterva_context_t *ctx, caterva_array_t *src, int64_
         default:
             CATERVA_ERROR(CATERVA_ERR_INVALID_STORAGE);
     }
+    (*array)->filled = true;
+    (*array)->empty = false;
 
     return CATERVA_SUCCEED;
 }
@@ -350,6 +355,8 @@ int caterva_array_copy(caterva_context_t *ctx, caterva_array_t *src, caterva_sto
         default:
             CATERVA_ERROR(CATERVA_ERR_INVALID_STORAGE);
     }
+    (*array)->filled = true;
+    (*array)->empty = false;
 
     return CATERVA_SUCCEED;
 }

--- a/caterva/caterva.h
+++ b/caterva/caterva.h
@@ -249,11 +249,11 @@ typedef struct {
     //!< Shape of original data.
     int32_t chunkshape[CATERVA_MAX_DIM];
     //!< Shape of each chunk. If @p storage equals to @p CATERVA_STORAGE_PLAINBUFFER, it is equal to @p shape.
-    int64_t extendedshape[CATERVA_MAX_DIM];
+    int64_t extshape[CATERVA_MAX_DIM];
     //!< Shape of padded data.
     int32_t blockshape[CATERVA_MAX_DIM];
     //!< Shape of each subpartition.
-    int64_t extendedchunkshape[CATERVA_MAX_DIM];
+    int64_t extchunkshape[CATERVA_MAX_DIM];
     //!< Shape of padded partition.
     int32_t next_chunkshape[CATERVA_MAX_DIM];
     //!< Shape of next partition to be appended.
@@ -261,11 +261,11 @@ typedef struct {
     //!< Size of original data.
     int32_t chunksize;
     //!< Size of each chunk.
-    int64_t extendedsize;
+    int64_t extsize;
     //!< Size of padded data.
     int32_t blocksize;
     //!< Size of each subpartition.
-    int64_t extendedchunksize;
+    int64_t extchunksize;
     //!< Size of padded partition.
     int64_t next_chunksize;
     //!< Size of next partiton to be appended.

--- a/caterva/caterva.h
+++ b/caterva/caterva.h
@@ -252,11 +252,11 @@ typedef struct {
     int64_t extshape[CATERVA_MAX_DIM];
     //!< Shape of padded data.
     int32_t blockshape[CATERVA_MAX_DIM];
-    //!< Shape of each subpartition.
+    //!< Shape of each block.
     int64_t extchunkshape[CATERVA_MAX_DIM];
-    //!< Shape of padded partition.
+    //!< Shape of padded chunk.
     int32_t next_chunkshape[CATERVA_MAX_DIM];
-    //!< Shape of next partition to be appended.
+    //!< Shape of next chunk to be appended.
     int64_t size;
     //!< Size of original data.
     int32_t chunksize;
@@ -264,11 +264,11 @@ typedef struct {
     int64_t extsize;
     //!< Size of padded data.
     int32_t blocksize;
-    //!< Size of each subpartition.
+    //!< Size of each block.
     int64_t extchunksize;
-    //!< Size of padded partition.
+    //!< Size of padded chunk.
     int64_t next_chunksize;
-    //!< Size of next partiton to be appended.
+    //!< Size of next chunk to be appended.
     int8_t ndim;
     //!< Data dimensions.
     int8_t itemsize;

--- a/caterva/caterva.h
+++ b/caterva/caterva.h
@@ -232,7 +232,7 @@ typedef struct {
     int64_t extendedchunkshape[CATERVA_MAXDIM];
     //!< Shape of padded partition.
     int32_t next_chunkshape[CATERVA_MAXDIM];
-    //!< Shape of next partition to be appened.
+    //!< Shape of next partition to be appended.
     int64_t size;
     //!< Size of original data.
     int32_t chunksize;
@@ -244,7 +244,7 @@ typedef struct {
     int64_t extendedchunksize;
     //!< Size of padded partition.
     int64_t next_chunksize;
-    //!< Size of next partiton to be appened.
+    //!< Size of next partiton to be appended.
     int8_t ndim;
     //!< Data dimensions.
     int8_t itemsize;

--- a/caterva/caterva.h
+++ b/caterva/caterva.h
@@ -325,21 +325,6 @@ int caterva_array_free(caterva_context_t *ctx, caterva_array_t **array);
 
 
 /**
- * @brief Reorders a buffer in order to be able to append subpartitions
- *
- * @param chunk Pointer to the buffer where data will be stored
- * @param size_chunk Size of the destination buffer
- * @param src A pointer to the buffer where data is stored
- * @param size_src Size of the source buffer
- * @param carr Pointer to the container where useful parameters are stored
- * @param ctx Pointer to the caterva context to be used
- *
- * @return An error code
- */
-int caterva_blosc_array_repart_chunk(int8_t *repartedchunk, int repartedchunksize, void *chunk, int chunksize, caterva_array_t *array);
-
-
-/**
  * Append a chunk to a caterva array (until it is completely filled).
  *
  * @param ctx Pointer to the caterva context to be used.

--- a/caterva/caterva_blosc.c
+++ b/caterva/caterva_blosc.c
@@ -575,7 +575,7 @@ int caterva_blosc_array_from_buffer(caterva_context_t *ctx, caterva_array_t *arr
             // Copy each chunk from rchunk to dest
             printf("\n chunk: \n");
             for (int i=0; i < array->chunksize; i++) {
-                printf("%hhu, ", chunk[i]);
+                printf("%f, ", ((double *) chunk)[i]);
             }
             caterva_blosc_array_repart_chunk(rchunk, (int) array->extendedchunksize * typesize, chunk,
                                              (int) array->chunksize * typesize, array);
@@ -583,7 +583,7 @@ int caterva_blosc_array_from_buffer(caterva_context_t *ctx, caterva_array_t *arr
 
             printf("\n rchunk: \n");
             for (int i=0; i < array->chunksize; i++) {
-                printf("%hhu, ", chunk[i]);
+                printf("%f, ", ((double*) chunk)[i]);
             }
             array->nparts++;
             if (array->nparts == array->extendedsize / array->chunksize) {

--- a/caterva/caterva_blosc.c
+++ b/caterva/caterva_blosc.c
@@ -629,7 +629,7 @@ int caterva_blosc_array_get_slice_buffer(caterva_context_t *ctx, caterva_array_t
     }
 
     // Acceleration path for the case where we are doing (1-dim) aligned chunk reads
-    if ((s_ndim == 1) && (array->chunkshape[0] == shape[0]) &&
+    if ((s_ndim == 1) && (array->chunkshape[0] == shape[0]) && (array->chunkshape[0] == array->blockshape[0]) &&
         (start[0] % array->chunkshape[0] == 0) && (stop[0] % array->chunkshape[0] == 0)) {
         int nchunk = (int)(start[0] / array->chunkshape[0]);
         // In case of an aligned read, decompress directly in destination

--- a/caterva/caterva_blosc.c
+++ b/caterva/caterva_blosc.c
@@ -561,9 +561,6 @@ int caterva_blosc_array_from_buffer(caterva_context_t *ctx, caterva_array_t *arr
                                         }
                                         memcpy(chunk + d_coord_f * typesize, bbuffer + s_coord_f * typesize,
                                                seq_copylen);
-
-                                        //printf("\n memcpy de buffer %ld (%hhd) a chunk %ld \n", s_coord_f,
-                                         //       bbuffer[s_coord_f], d_coord_f);
                                     }
                                 }
                             }
@@ -572,23 +569,9 @@ int caterva_blosc_array_from_buffer(caterva_context_t *ctx, caterva_array_t *arr
                 }
             }
             // Copy each chunk from rchunk to dest
-            printf("\n chunk: \n");
-            for (int i=0; i < array->chunksize ; i++) {
-                if (typesize == 4) {
-                    printf("%f, ", ((float*) chunk)[i] );
-                } else {
-                    printf("%f, ", ((double*) chunk)[i] );
-                }
-            }
             caterva_blosc_array_repart_chunk(rchunk, (int) array->extendedchunksize * typesize, chunk,
                                              (int) array->chunksize * typesize, array);
-            printf("\n rchunk: \n");
-            for (int i=0; i < array->extendedchunksize ; i++) {
-                if (typesize == 4) {
-                    printf("%f, ", ((float*) rchunk)[i] );
-                } else {
-                    printf("%f, ", ((double*) rchunk)[i] );
-                }            }
+
             blosc2_schunk_append_buffer(array->sc, rchunk, (size_t) array->extendedchunksize * typesize);
             array->empty = false;
             array->nparts++;
@@ -604,8 +587,8 @@ int caterva_blosc_array_from_buffer(caterva_context_t *ctx, caterva_array_t *arr
 }
 
 
-int caterva_blosc_array_get_slice_buffer(caterva_context_t *ctx, caterva_array_t *array, int64_t *start,
-                                         int64_t *stop, int64_t *shape, void *buffer) {
+int caterva_blosc_array_get_slice_buffer(caterva_context_t *ctx, caterva_array_t *array, const int64_t *start,
+                                         const int64_t *stop, const int64_t *shape, void *buffer) {
     uint8_t *bbuffer = buffer;   // for allowing pointer arithmetic
 
     int64_t start__[CATERVA_MAX_DIM];
@@ -661,7 +644,7 @@ int caterva_blosc_array_get_slice_buffer(caterva_context_t *ctx, caterva_array_t
     }
     /* Create chunk buffers */
     int typesize = array->itemsize;
-    int nblocks = array->extendedchunksize / array->blocksize;
+    int nblocks = ((int) array->extendedchunksize) / array->blocksize;
     bool *block_maskout = ctx->cfg->alloc(nblocks);
 
     uint8_t *chunk;
@@ -681,7 +664,6 @@ int caterva_blosc_array_get_slice_buffer(caterva_context_t *ctx, caterva_array_t
     }
 
     /* Calculate the used chunks */
-    bool needs_free = false;
     int64_t ii[CATERVA_MAX_DIM], jj[CATERVA_MAX_DIM], kk[CATERVA_MAX_DIM];
     int64_t j_start[CATERVA_MAX_DIM], j_stop[CATERVA_MAX_DIM];
     int64_t sp_start[CATERVA_MAX_DIM], sp_stop[CATERVA_MAX_DIM];
@@ -914,15 +896,6 @@ int caterva_blosc_array_get_slice(caterva_context_t *ctx, caterva_array_t *src, 
 
                                     CATERVA_ERROR(caterva_array_get_slice_buffer(ctx, src, start_, stop_, d_pshape_,
                                                                                  chunk, array->next_chunksize * typesize));
-
-                                    printf("\n get_slice_buffer: \n");
-                                    for (int i=0; i < (array->next_chunksize); i++) {
-                                        if (typesize == 4) {
-                                            printf("%f, ", ((float*) chunk)[i] );
-                                        } else {
-                                            printf("%f, ", ((double*) chunk)[i] );
-                                        }
-                                    }
 
                                     CATERVA_ERROR(caterva_array_append(ctx, array, chunk, array->next_chunksize * typesize));
                                     for (int i = 0; i < src->ndim; ++i) {

--- a/caterva/caterva_blosc.c
+++ b/caterva/caterva_blosc.c
@@ -443,7 +443,7 @@ int caterva_blosc_array_append(caterva_context_t *ctx, caterva_array_t *array, v
             }
         }
         caterva_blosc_array_repart_chunk(repartedchunk, size_rep, paddedchunk, size_chunk, array);
-        ctx->cfg->free(chunk);
+        free(paddedchunk);
     } else {
         caterva_blosc_array_repart_chunk(repartedchunk, size_rep, chunk, chunksize, array);
     }
@@ -470,9 +470,9 @@ int caterva_blosc_array_append(caterva_context_t *ctx, caterva_array_t *array, v
     for (int i = CATERVA_MAX_DIM - 2; i >= 0; i--) {
         aux[i] = c_eshape[i] / c_pshape[i] * aux[i + 1];
     }
-    poschunk[7] = array->nparts % aux[7];
+    poschunk[7] = (array->nparts + 1) % aux[7];
     for (int i = CATERVA_MAX_DIM - 2; i >= 0; i--) {
-        poschunk[i] = (array->nparts % aux[i]) / aux[i + 1];
+        poschunk[i] = ((array->nparts + 1) % aux[i]) / aux[i + 1];
     }
 
     // Update next_chunkshape, next_chunksize

--- a/caterva/caterva_blosc.c
+++ b/caterva/caterva_blosc.c
@@ -561,6 +561,9 @@ int caterva_blosc_array_from_buffer(caterva_context_t *ctx, caterva_array_t *arr
                                         }
                                         memcpy(chunk + d_coord_f * typesize, bbuffer + s_coord_f * typesize,
                                                seq_copylen);
+
+                                        //printf("\n memcpy de buffer %ld (%hhd) a chunk %ld \n", s_coord_f,
+                                         //       bbuffer[s_coord_f], d_coord_f);
                                     }
                                 }
                             }
@@ -571,14 +574,21 @@ int caterva_blosc_array_from_buffer(caterva_context_t *ctx, caterva_array_t *arr
             // Copy each chunk from rchunk to dest
             printf("\n chunk: \n");
             for (int i=0; i < array->chunksize ; i++) {
-                printf("%hhu, ",  chunk[i]);
+                if (typesize == 4) {
+                    printf("%f, ", ((float*) chunk)[i] );
+                } else {
+                    printf("%f, ", ((double*) chunk)[i] );
+                }
             }
             caterva_blosc_array_repart_chunk(rchunk, (int) array->extendedchunksize * typesize, chunk,
                                              (int) array->chunksize * typesize, array);
             printf("\n rchunk: \n");
             for (int i=0; i < array->extendedchunksize ; i++) {
-                printf("%hhu, ",  rchunk[i]);
-            }
+                if (typesize == 4) {
+                    printf("%f, ", ((float*) rchunk)[i] );
+                } else {
+                    printf("%f, ", ((double*) rchunk)[i] );
+                }            }
             blosc2_schunk_append_buffer(array->sc, rchunk, (size_t) array->extendedchunksize * typesize);
             array->empty = false;
             array->nparts++;
@@ -904,6 +914,16 @@ int caterva_blosc_array_get_slice(caterva_context_t *ctx, caterva_array_t *src, 
 
                                     CATERVA_ERROR(caterva_array_get_slice_buffer(ctx, src, start_, stop_, d_pshape_,
                                                                                  chunk, array->next_chunksize * typesize));
+
+                                    printf("\n get_slice_buffer: \n");
+                                    for (int i=0; i < (array->next_chunksize); i++) {
+                                        if (typesize == 4) {
+                                            printf("%f, ", ((float*) chunk)[i] );
+                                        } else {
+                                            printf("%f, ", ((double*) chunk)[i] );
+                                        }
+                                    }
+
                                     CATERVA_ERROR(caterva_array_append(ctx, array, chunk, array->next_chunksize * typesize));
                                     for (int i = 0; i < src->ndim; ++i) {
                                         d_pshape[(CATERVA_MAX_DIM - d_ndim + i) % CATERVA_MAX_DIM] = array->next_chunkshape[i];

--- a/caterva/caterva_blosc.c
+++ b/caterva/caterva_blosc.c
@@ -577,22 +577,22 @@ int caterva_blosc_array_from_buffer(caterva_context_t *ctx, caterva_array_t *arr
                 }
             }
             // Copy each chunk from rchunk to dest
-            /*
+
             printf("\n chunk: \n");
             for (int i=0; i < array->chunksize; i++) {
                 printf("%f, ", ((double *) chunk)[i]);
             }
-             */
+
             caterva_blosc_array_repart_chunk(rchunk, (int) array->extendedchunksize * typesize, chunk,
                                              (int) array->chunksize * typesize, array);
             blosc2_schunk_append_buffer(array->sc, rchunk, (size_t) array->extendedchunksize * typesize);
             array->empty = false;
-            /*
+
             printf("\n rchunk: \n");
             for (int i=0; i < array->chunksize; i++) {
                 printf("%f, ", ((double*) rchunk)[i]);
             }
-             */
+
             array->nparts++;
             if (array->nparts == array->extendedsize / array->chunksize) {
                 array->filled = true;
@@ -805,8 +805,11 @@ int caterva_blosc_array_get_slice_buffer(caterva_context_t *ctx, caterva_array_t
                                                                                                                     ii[i] - start_[i]) * buf_pointer_inc;
                                                                                                     buf_pointer_inc *= d_pshape_[i];
                                                                                                 }
+
                                                                                                 memcpy(&bbuffer[buf_pointer * typesize],&chunk[(s_start + sp_pointer)
                                                                                                        * typesize],(sp_stop[7] - sp_start[7]) * typesize);
+                                                                                                printf("\n memcpy %ld elementos de chunk %ld (%f) a bbufer %ld (%f) \n", (sp_stop[7] - sp_start[7]),
+                                                                                                       (s_start + sp_pointer), ((double *) chunk)[(s_start + sp_pointer)], buf_pointer, ((double*) bbuffer)[buf_pointer]);
                                                                                             }
                                                                                         }
                                                                                     }

--- a/caterva/caterva_blosc.c
+++ b/caterva/caterva_blosc.c
@@ -11,7 +11,7 @@
 
 #include <caterva.h>
 #include "assert.h"
-#include <unistd.h>
+
 
 // big <-> little-endian and store it in a memory position.  Sizes supported: 1, 2, 4, 8 bytes.
 static void swap_store(void *dest, const void *pa, int size) {

--- a/caterva/caterva_blosc.c
+++ b/caterva/caterva_blosc.c
@@ -590,8 +590,8 @@ int caterva_blosc_array_from_buffer(caterva_context_t *ctx, caterva_array_t *arr
 }
 
 
-int caterva_blosc_array_get_slice_buffer(caterva_context_t *ctx, caterva_array_t *array, const int64_t *start,
-                                         const int64_t *stop, const int64_t *shape, void *buffer) {
+int caterva_blosc_array_get_slice_buffer(caterva_context_t *ctx, caterva_array_t *array, int64_t *start,
+                                         int64_t *stop, const int64_t *shape, void *buffer) {
     uint8_t *bbuffer = buffer;   // for allowing pointer arithmetic
 
     int64_t start__[CATERVA_MAX_DIM];
@@ -829,8 +829,8 @@ int caterva_blosc_array_get_slice_buffer(caterva_context_t *ctx, caterva_array_t
 int caterva_blosc_array_to_buffer(caterva_context_t *ctx, caterva_array_t *array, void *buffer) {
     int8_t *bbuffer = (int8_t *) buffer;
     int8_t ndim = array->ndim;
-    int64_t start[ndim];
-    int64_t stop[ndim];
+    int64_t start[CATERVA_MAX_DIM];
+    int64_t stop[CATERVA_MAX_DIM];
     for(int i=0; i<ndim; i++) {
         start[i] = 0;
         stop[i] = array->shape[i];

--- a/caterva/caterva_blosc.c
+++ b/caterva/caterva_blosc.c
@@ -392,6 +392,7 @@ int caterva_blosc_array_repart_chunk(int8_t *repartedchunk, int repartedchunksiz
 int caterva_blosc_array_append(caterva_context_t *ctx, caterva_array_t *array, void *chunk, int64_t chunksize) {
     CATERVA_UNUSED_PARAM(ctx);
 
+    uint8_t *bchunk = (uint8_t *) chunk;
     int64_t typesize = array->itemsize;
     int64_t size_rep = array->extendedchunksize * typesize;
     int8_t *repartedchunk = ctx->cfg->alloc(size_rep);
@@ -433,7 +434,7 @@ int caterva_blosc_array_append(caterva_context_t *ctx, caterva_array_t *array, v
                                     }
                                     if (! blank) {
                                         memcpy(paddedchunk + ind_dest * array->itemsize,
-                                               chunk + ind_src * array->itemsize,
+                                               bchunk + ind_src * array->itemsize,
                                                seq_copylen);
                                         ind_src += next_pshape[7];
                                     }
@@ -448,7 +449,7 @@ int caterva_blosc_array_append(caterva_context_t *ctx, caterva_array_t *array, v
         caterva_blosc_array_repart_chunk(repartedchunk, size_rep, paddedchunk, size_chunk, array);
         ctx->cfg->free(paddedchunk);
     } else {
-        caterva_blosc_array_repart_chunk(repartedchunk, size_rep, chunk, chunksize, array);
+        caterva_blosc_array_repart_chunk(repartedchunk, size_rep, bchunk, chunksize, array);
     }
     if (blosc2_schunk_append_buffer(array->sc, repartedchunk, size_rep) < 0) {
         CATERVA_ERROR(CATERVA_ERR_BLOSC_FAILED);

--- a/caterva/caterva_blosc.c
+++ b/caterva/caterva_blosc.c
@@ -867,6 +867,9 @@ int caterva_blosc_array_get_slice(caterva_context_t *ctx, caterva_array_t *src, 
     }
     int64_t ii[CATERVA_MAX_DIM];
     int64_t appended_shape[CATERVA_MAX_DIM];
+    for (int i = 0; i < CATERVA_MAX_DIM; ++i) {
+        appended_shape[i] = 0;  // assigned to 0 for fixing warring
+    }
     for (ii[0] = d_start[0]; ii[0] < d_stop[0]; ii[0] += appended_shape[0]) {
         for (ii[1] = d_start[1]; ii[1] < d_stop[1]; ii[1] += appended_shape[1]) {
             for (ii[2] = d_start[2]; ii[2] < d_stop[2]; ii[2] += appended_shape[2]) {

--- a/caterva/caterva_blosc.c
+++ b/caterva/caterva_blosc.c
@@ -578,21 +578,10 @@ int caterva_blosc_array_from_buffer(caterva_context_t *ctx, caterva_array_t *arr
             }
             // Copy each chunk from rchunk to dest
 
-            printf("\n chunk: \n");
-            for (int i=0; i < array->chunksize; i++) {
-                printf("%f, ", ((double *) chunk)[i]);
-            }
-
             caterva_blosc_array_repart_chunk(rchunk, (int) array->extendedchunksize * typesize, chunk,
                                              (int) array->chunksize * typesize, array);
             blosc2_schunk_append_buffer(array->sc, rchunk, (size_t) array->extendedchunksize * typesize);
             array->empty = false;
-
-            printf("\n rchunk: \n");
-            for (int i=0; i < array->chunksize; i++) {
-                printf("%f, ", ((double*) rchunk)[i]);
-            }
-
             array->nparts++;
             if (array->nparts == array->extendedsize / array->chunksize) {
                 array->filled = true;
@@ -775,6 +764,12 @@ int caterva_blosc_array_get_slice_buffer(caterva_context_t *ctx, caterva_array_t
                                                                         } else {
                                                                             sp_stop[i] = s_spshape[i];
                                                                         }
+                                                                        if ((jj[i] + 1) * s_spshape[i] > s_pshape[i]) { // case padding
+                                                                            int64_t lastn = s_pshape[i] % s_spshape[i];
+                                                                            if (lastn < sp_stop[i]) {
+                                                                                sp_stop[i] = lastn;
+                                                                            }
+                                                                        }
                                                                     }
                                                                     kk[7] = sp_start[7];
                                                                     for (kk[0] = sp_start[0]; kk[0] < sp_stop[0]; ++kk[0]) {
@@ -784,13 +779,6 @@ int caterva_blosc_array_get_slice_buffer(caterva_context_t *ctx, caterva_array_t
                                                                                     for (kk[4] = sp_start[4]; kk[4] < sp_stop[4]; ++kk[4]) {
                                                                                         for (kk[5] = sp_start[5]; kk[5] < sp_stop[5]; ++kk[5]) {
                                                                                             for (kk[6] = sp_start[6]; kk[6] < sp_stop[6]; ++kk[6]) {
-                                                                                                // case padding in dim7
-                                                                                                if ((jj[7] + 1) * s_spshape[7] > s_pshape[7]) {
-                                                                                                    int64_t lastn = s_pshape[7] % s_spshape[7];
-                                                                                                    if (lastn < sp_stop[7]) {
-                                                                                                        sp_stop[7] = lastn;
-                                                                                                    }
-                                                                                                }
                                                                                                 // Copy each line of data from spart to bdest
                                                                                                 int64_t sp_pointer = 0;
                                                                                                 int64_t sp_pointer_inc = 1;
@@ -808,8 +796,6 @@ int caterva_blosc_array_get_slice_buffer(caterva_context_t *ctx, caterva_array_t
 
                                                                                                 memcpy(&bbuffer[buf_pointer * typesize],&chunk[(s_start + sp_pointer)
                                                                                                        * typesize],(sp_stop[7] - sp_start[7]) * typesize);
-                                                                                                printf("\n memcpy %ld elementos de chunk %ld (%f) a bbufer %ld (%f) \n", (sp_stop[7] - sp_start[7]),
-                                                                                                       (s_start + sp_pointer), ((double *) chunk)[(s_start + sp_pointer)], buf_pointer, ((double*) bbuffer)[buf_pointer]);
                                                                                             }
                                                                                         }
                                                                                     }

--- a/caterva/caterva_blosc.c
+++ b/caterva/caterva_blosc.c
@@ -761,54 +761,52 @@ int caterva_blosc_array_get_slice_buffer(caterva_context_t *ctx, caterva_array_t
                                                                         nspart += (int) (jj[i] * sinc);
                                                                         sinc *= (int) (s_epshape[i] / s_spshape[i]);
                                                                     }
-                                                                    if (! block_maskout[nspart]) {
 
-                                                                        s_start = nspart * array->blocksize;
-                                                                        /* memcpy */
-                                                                        for (int i = 0; i < CATERVA_MAX_DIM; ++i) {
-                                                                            if (jj[i] == j_start[i] && ii[i] == i_start[i]) {
-                                                                                sp_start[i] = (start_[i] % s_pshape[i]) % s_spshape[i];
-                                                                            } else {
-                                                                                sp_start[i] = 0;
-                                                                            }
-                                                                            if (jj[i] == j_stop[i] && ii[i] == i_stop[i]) {
-                                                                                sp_stop[i] = (((stop_[i] - 1) % s_pshape[i]) % s_spshape[i]) + 1;
-                                                                            } else {
-                                                                                sp_stop[i] = s_spshape[i];
-                                                                            }
+                                                                    s_start = nspart * array->blocksize;
+                                                                    /* memcpy */
+                                                                    for (int i = 0; i < CATERVA_MAX_DIM; ++i) {
+                                                                        if (jj[i] == j_start[i] && ii[i] == i_start[i]) {
+                                                                            sp_start[i] = (start_[i] % s_pshape[i]) % s_spshape[i];
+                                                                        } else {
+                                                                            sp_start[i] = 0;
                                                                         }
-                                                                        kk[7] = sp_start[7];
-                                                                        for (kk[0] = sp_start[0]; kk[0] < sp_stop[0]; ++kk[0]) {
-                                                                            for (kk[1] = sp_start[1]; kk[1] < sp_stop[1]; ++kk[1]) {
-                                                                                for (kk[2] = sp_start[2]; kk[2] < sp_stop[2]; ++kk[2]) {
-                                                                                    for (kk[3] = sp_start[3]; kk[3] < sp_stop[3]; ++kk[3]) {
-                                                                                        for (kk[4] = sp_start[4]; kk[4] < sp_stop[4]; ++kk[4]) {
-                                                                                            for (kk[5] = sp_start[5]; kk[5] < sp_stop[5]; ++kk[5]) {
-                                                                                                for (kk[6] = sp_start[6]; kk[6] < sp_stop[6]; ++kk[6]) {
-                                                                                                    // case padding in dim7
-                                                                                                    if ((jj[7] + 1) * s_spshape[7] > s_pshape[7]) {
-                                                                                                        int64_t lastn = s_pshape[7] % s_spshape[7];
-                                                                                                        if (lastn < sp_stop[7]) {
-                                                                                                            sp_stop[7] = lastn;
-                                                                                                        }
+                                                                        if (jj[i] == j_stop[i] && ii[i] == i_stop[i]) {
+                                                                            sp_stop[i] = (((stop_[i] - 1) % s_pshape[i]) % s_spshape[i]) + 1;
+                                                                        } else {
+                                                                            sp_stop[i] = s_spshape[i];
+                                                                        }
+                                                                    }
+                                                                    kk[7] = sp_start[7];
+                                                                    for (kk[0] = sp_start[0]; kk[0] < sp_stop[0]; ++kk[0]) {
+                                                                        for (kk[1] = sp_start[1]; kk[1] < sp_stop[1]; ++kk[1]) {
+                                                                            for (kk[2] = sp_start[2]; kk[2] < sp_stop[2]; ++kk[2]) {
+                                                                                for (kk[3] = sp_start[3]; kk[3] < sp_stop[3]; ++kk[3]) {
+                                                                                    for (kk[4] = sp_start[4]; kk[4] < sp_stop[4]; ++kk[4]) {
+                                                                                        for (kk[5] = sp_start[5]; kk[5] < sp_stop[5]; ++kk[5]) {
+                                                                                            for (kk[6] = sp_start[6]; kk[6] < sp_stop[6]; ++kk[6]) {
+                                                                                                // case padding in dim7
+                                                                                                if ((jj[7] + 1) * s_spshape[7] > s_pshape[7]) {
+                                                                                                    int64_t lastn = s_pshape[7] % s_spshape[7];
+                                                                                                    if (lastn < sp_stop[7]) {
+                                                                                                        sp_stop[7] = lastn;
                                                                                                     }
-                                                                                                    // Copy each line of data from spart to bdest
-                                                                                                    int64_t sp_pointer = 0;
-                                                                                                    int64_t sp_pointer_inc = 1;
-                                                                                                    for (int i = CATERVA_MAX_DIM - 1; i >= 0; --i) {
-                                                                                                        sp_pointer += kk[i] * sp_pointer_inc;
-                                                                                                        sp_pointer_inc *= s_spshape[i];
-                                                                                                    }
-                                                                                                    int64_t buf_pointer = 0;
-                                                                                                    int64_t buf_pointer_inc = 1;
-                                                                                                    for (int i = CATERVA_MAX_DIM - 1; i >= 0; --i) {
-                                                                                                        buf_pointer += (kk[i] + s_spshape[i] * jj[i] + s_pshape[i] *
-                                                                                                                        ii[i] - start_[i]) * buf_pointer_inc;
-                                                                                                        buf_pointer_inc *= d_pshape_[i];
-                                                                                                    }
-                                                                                                    memcpy(&bbuffer[buf_pointer * typesize],&chunk[(s_start + sp_pointer)
-                                                                                                           * typesize],(sp_stop[7] - sp_start[7]) * typesize);
                                                                                                 }
+                                                                                                // Copy each line of data from spart to bdest
+                                                                                                int64_t sp_pointer = 0;
+                                                                                                int64_t sp_pointer_inc = 1;
+                                                                                                for (int i = CATERVA_MAX_DIM - 1; i >= 0; --i) {
+                                                                                                    sp_pointer += kk[i] * sp_pointer_inc;
+                                                                                                    sp_pointer_inc *= s_spshape[i];
+                                                                                                }
+                                                                                                int64_t buf_pointer = 0;
+                                                                                                int64_t buf_pointer_inc = 1;
+                                                                                                for (int i = CATERVA_MAX_DIM - 1; i >= 0; --i) {
+                                                                                                    buf_pointer += (kk[i] + s_spshape[i] * jj[i] + s_pshape[i] *
+                                                                                                                    ii[i] - start_[i]) * buf_pointer_inc;
+                                                                                                    buf_pointer_inc *= d_pshape_[i];
+                                                                                                }
+                                                                                                memcpy(&bbuffer[buf_pointer * typesize],&chunk[(s_start + sp_pointer)
+                                                                                                       * typesize],(sp_stop[7] - sp_start[7]) * typesize);
                                                                                             }
                                                                                         }
                                                                                     }
@@ -1129,10 +1127,12 @@ int caterva_blosc_array_empty(caterva_context_t *ctx, caterva_params_t *params, 
         DEBUG_PRINT("error during serializing dims info for Caterva");
         return CATERVA_ERR_BLOSC_FAILED;
     }
+
     // And store it in caterva metalayer
     if (blosc2_add_metalayer(sc, "caterva", smeta, (uint32_t)smeta_len) < 0) {
         return CATERVA_ERR_BLOSC_FAILED;
     }
+
     free(smeta);
 
     for (int i = 0; i < storage->properties.blosc.nmetalayers; ++i) {

--- a/caterva/caterva_blosc.h
+++ b/caterva/caterva_blosc.h
@@ -26,6 +26,9 @@ int caterva_blosc_from_sframe(caterva_context_t *ctx, uint8_t *sframe, int64_t l
 int caterva_blosc_from_file(caterva_context_t *ctx, const char *filename, bool copy, caterva_array_t **array);
 
 
+int caterva_blosc_array_repart_chunk(int8_t *repartedchunk, int repartedchunksize, void *chunk, int chunksize, caterva_array_t *array);
+
+
 int caterva_blosc_array_append(caterva_context_t *ctx, caterva_array_t *array, void *chunk, int64_t chunksize);
 
 

--- a/caterva/caterva_blosc.h
+++ b/caterva/caterva_blosc.h
@@ -31,11 +31,11 @@ int caterva_blosc_array_append(caterva_context_t *ctx, caterva_array_t *array, v
 
 int caterva_blosc_array_from_buffer(caterva_context_t *ctx, caterva_array_t *array, void *buffer, int64_t buffersize);
 
-int caterva_blosc_array_to_buffer(caterva_context_t *ctx, caterva_array_t *array, void *buffer);
-
 
 int caterva_blosc_array_get_slice_buffer(caterva_context_t *ctx, caterva_array_t *array, int64_t *start,
                                          int64_t *stop, int64_t *shape, void *buffer);
+
+int caterva_blosc_array_to_buffer(caterva_context_t *ctx, caterva_array_t *array, void *buffer);
 
 int caterva_blosc_array_get_slice(caterva_context_t *ctx, caterva_array_t *src, int64_t *start, int64_t *stop,
                                   caterva_array_t *array);

--- a/caterva/caterva_plainbuffer.c
+++ b/caterva/caterva_plainbuffer.c
@@ -197,20 +197,20 @@ int caterva_plainbuffer_array_get_slice(caterva_context_t *ctx, caterva_array_t 
 int caterva_plainbuffer_update_shape(caterva_array_t *array, int8_t ndim, int64_t *shape) {
     array->ndim = ndim;
     array->size = 1;
-    array->extendedsize = 1;
+    array->extsize = 1;
     array->chunksize = 1;
     for (int i = 0; i < CATERVA_MAX_DIM; ++i) {
         if (i < ndim) {
             array->shape[i] = shape[i];
-            array->extendedshape[i] = shape[i];
+            array->extshape[i] = shape[i];
             array->chunkshape[i] = (int32_t) (shape[i]);
         } else {
             array->shape[i] = 1;
-            array->extendedshape[i] = 1;
+            array->extshape[i] = 1;
             array->chunkshape[i] = 1;
         }
         array->size *= array->shape[i];
-        array->extendedsize *= array->extendedshape[i];
+        array->extsize *= array->extshape[i];
         array->chunksize *= array->chunkshape[i];
     }
 
@@ -265,22 +265,22 @@ int caterva_plainbuffer_array_empty(caterva_context_t *ctx, caterva_params_t *pa
 
     (*array)->size = 1;
     (*array)->chunksize = 1;
-    (*array)->extendedsize = 1;
+    (*array)->extsize = 1;
 
     for (int i = 0; i < params->ndim; ++i) {
         (*array)->shape[i] = shape[i];
         (*array)->chunkshape[i] = shape[i];
-        (*array)->extendedshape[i] = shape[i];
+        (*array)->extshape[i] = shape[i];
 
         (*array)->size *= shape[i];
         (*array)->chunksize *= shape[i];
-        (*array)->extendedsize *= shape[i];
+        (*array)->extsize *= shape[i];
     }
 
     for (int i = params->ndim; i < CATERVA_MAX_DIM; ++i) {
         (*array)->shape[i] = 1;
         (*array)->chunkshape[i] = 1;
-        (*array)->extendedshape[i] = 1;
+        (*array)->extshape[i] = 1;
     }
 
     // The partition cache (empty initially)
@@ -289,7 +289,7 @@ int caterva_plainbuffer_array_empty(caterva_context_t *ctx, caterva_params_t *pa
 
     (*array)->sc = NULL;
 
-    uint8_t *buf = ctx->cfg->alloc((*array)->extendedsize * params->itemsize);
+    uint8_t *buf = ctx->cfg->alloc((*array)->extsize * params->itemsize);
 
     (*array)->buf = buf;
 

--- a/caterva/caterva_plainbuffer.c
+++ b/caterva/caterva_plainbuffer.c
@@ -22,10 +22,6 @@ int caterva_plainbuffer_array_free(caterva_context_t *ctx, caterva_array_t **arr
 
 
 int caterva_plainbuffer_array_append(caterva_context_t *ctx, caterva_array_t *array, void *chunk, int64_t chunksize) {
-    if (array->nparts == 0) {
-        array->buf = ctx->cfg->alloc(array->size * array->itemsize);
-        CATERVA_ERROR_NULL(array->buf);
-    }
 
     int64_t start[CATERVA_MAX_DIM];
     int64_t stop[CATERVA_MAX_DIM];
@@ -190,7 +186,6 @@ int caterva_plainbuffer_array_get_slice(caterva_context_t *ctx, caterva_array_t 
     for (int i = 0; i < src->ndim; ++i) {
         size *= stop[i] - start[i];
     }
-    array->buf = ctx->cfg->alloc(size * typesize);
     CATERVA_ERROR(caterva_array_get_slice_buffer(ctx, src, start, stop, array->shape, array->buf, size * typesize));
     array->filled = true;
     array->empty = false;
@@ -246,7 +241,6 @@ int caterva_plainbuffer_array_copy(caterva_context_t *ctx, caterva_params_t *par
 
     CATERVA_ERROR(caterva_array_empty(ctx, params, storage, dest));
 
-    (*dest)->buf = ctx->cfg->alloc((size_t) (*dest)->size * (*dest)->itemsize);
     CATERVA_ERROR(caterva_array_to_buffer(ctx, src, (*dest)->buf, (*dest)->size * (*dest)->itemsize));
     (*dest)->filled = true;
 

--- a/caterva/caterva_plainbuffer.c
+++ b/caterva/caterva_plainbuffer.c
@@ -27,7 +27,8 @@ int caterva_plainbuffer_array_append(caterva_context_t *ctx, caterva_array_t *ar
         CATERVA_ERROR_NULL(array->buf);
     }
 
-    int64_t start[CATERVA_MAXDIM], stop[CATERVA_MAXDIM];
+    int64_t start[CATERVA_MAX_DIM];
+    int64_t stop[CATERVA_MAX_DIM];
     for (int i = 0; i < array->ndim; ++i) {
         start[i] = 0;
         stop[i] = start[i] + array->chunkshape[i];
@@ -57,12 +58,12 @@ int caterva_plainbuffer_array_get_slice_buffer(caterva_context_t *ctx, caterva_a
 
     CATERVA_UNUSED_PARAM(ctx);
 
-    int64_t start__[CATERVA_MAXDIM];
-    int64_t stop__[CATERVA_MAXDIM];
-    int64_t shape__[CATERVA_MAXDIM];
-    int64_t shape2__[CATERVA_MAXDIM];
+    int64_t start__[CATERVA_MAX_DIM];
+    int64_t stop__[CATERVA_MAX_DIM];
+    int64_t shape__[CATERVA_MAX_DIM];
+    int64_t shape2__[CATERVA_MAX_DIM];
 
-    for (int i = 0; i < CATERVA_MAXDIM; ++i) {
+    for (int i = 0; i < CATERVA_MAX_DIM; ++i) {
         start__[i] = (i < array->ndim) ? start[i] : 0;
         stop__[i] = (i < array->ndim) ? stop[i] : 1;
         shape__[i] = (i < array->ndim) ? array->shape[i] : 1;
@@ -70,22 +71,22 @@ int caterva_plainbuffer_array_get_slice_buffer(caterva_context_t *ctx, caterva_a
     }
 
     uint8_t *bdest = buffer;   // for allowing pointer arithmetic
-    int64_t start_[CATERVA_MAXDIM];
-    int64_t stop_[CATERVA_MAXDIM];
-    int64_t d_pshape_[CATERVA_MAXDIM];
+    int64_t start_[CATERVA_MAX_DIM];
+    int64_t stop_[CATERVA_MAX_DIM];
+    int64_t d_pshape_[CATERVA_MAX_DIM];
     int8_t s_ndim = array->ndim;
 
-    int64_t s_shape[CATERVA_MAXDIM];
-    for (int i = 0; i < CATERVA_MAXDIM; ++i) {
-        start_[(CATERVA_MAXDIM - s_ndim + i) % CATERVA_MAXDIM] = start__[i];
-        stop_[(CATERVA_MAXDIM - s_ndim + i) % CATERVA_MAXDIM] = stop__[i];
-        s_shape[(CATERVA_MAXDIM - s_ndim + i) % CATERVA_MAXDIM] = shape__[i];
-        d_pshape_[(CATERVA_MAXDIM - s_ndim + i) % CATERVA_MAXDIM] = shape2__[i];
+    int64_t s_shape[CATERVA_MAX_DIM];
+    for (int i = 0; i < CATERVA_MAX_DIM; ++i) {
+        start_[(CATERVA_MAX_DIM - s_ndim + i) % CATERVA_MAX_DIM] = start__[i];
+        stop_[(CATERVA_MAX_DIM - s_ndim + i) % CATERVA_MAX_DIM] = stop__[i];
+        s_shape[(CATERVA_MAX_DIM - s_ndim + i) % CATERVA_MAX_DIM] = shape__[i];
+        d_pshape_[(CATERVA_MAX_DIM - s_ndim + i) % CATERVA_MAX_DIM] = shape2__[i];
     }
-    for (int j = 0; j < CATERVA_MAXDIM - s_ndim; ++j) {
+    for (int j = 0; j < CATERVA_MAX_DIM - s_ndim; ++j) {
         start_[j] = 0;
     }
-    int64_t jj[CATERVA_MAXDIM];
+    int64_t jj[CATERVA_MAX_DIM];
     jj[7] = start_[7];
     for (jj[0] = start_[0]; jj[0] < stop_[0]; ++jj[0]) {
         for (jj[1] = start_[1]; jj[1] < stop_[1]; ++jj[1]) {
@@ -96,13 +97,13 @@ int caterva_plainbuffer_array_get_slice_buffer(caterva_context_t *ctx, caterva_a
                             for (jj[6] = start_[6]; jj[6] < stop_[6]; ++jj[6]) {
                                 int64_t chunk_pointer = 0;
                                 int64_t chunk_pointer_inc = 1;
-                                for (int i = CATERVA_MAXDIM - 1; i >= 0; --i) {
+                                for (int i = CATERVA_MAX_DIM - 1; i >= 0; --i) {
                                     chunk_pointer += jj[i] * chunk_pointer_inc;
                                     chunk_pointer_inc *= s_shape[i];
                                 }
                                 int64_t buf_pointer = 0;
                                 int64_t buf_pointer_inc = 1;
-                                for (int i = CATERVA_MAXDIM - 1; i >= 0; --i) {
+                                for (int i = CATERVA_MAX_DIM - 1; i >= 0; --i) {
                                     buf_pointer += (jj[i] - start_[i]) * buf_pointer_inc;
                                     buf_pointer_inc *= d_pshape_[i];
                                 }
@@ -127,25 +128,25 @@ int caterva_plainbuffer_array_set_slice_buffer(caterva_context_t *ctx, void *buf
     CATERVA_UNUSED_PARAM(buffersize);
 
     uint8_t *bbuffer = buffer;   // for allowing pointer arithmetic
-    int64_t start_[CATERVA_MAXDIM];
-    int64_t stop_[CATERVA_MAXDIM];
+    int64_t start_[CATERVA_MAX_DIM];
+    int64_t stop_[CATERVA_MAX_DIM];
     int8_t s_ndim = array->ndim;
 
-    int64_t d_shape[CATERVA_MAXDIM];
-    int64_t s_shape[CATERVA_MAXDIM];
-    for (int i = 0; i < CATERVA_MAXDIM; ++i) {
-        start_[(CATERVA_MAXDIM - s_ndim + i) % CATERVA_MAXDIM] = start[i];
-        stop_[(CATERVA_MAXDIM - s_ndim + i) % CATERVA_MAXDIM] = stop[i];
-        d_shape[(CATERVA_MAXDIM - s_ndim + i) % CATERVA_MAXDIM] = (stop[i] - start[i]);
-        s_shape[(CATERVA_MAXDIM - s_ndim + i) % CATERVA_MAXDIM] = array->shape[i];
+    int64_t d_shape[CATERVA_MAX_DIM];
+    int64_t s_shape[CATERVA_MAX_DIM];
+    for (int i = 0; i < CATERVA_MAX_DIM; ++i) {
+        start_[(CATERVA_MAX_DIM - s_ndim + i) % CATERVA_MAX_DIM] = start[i];
+        stop_[(CATERVA_MAX_DIM - s_ndim + i) % CATERVA_MAX_DIM] = stop[i];
+        d_shape[(CATERVA_MAX_DIM - s_ndim + i) % CATERVA_MAX_DIM] = (stop[i] - start[i]);
+        s_shape[(CATERVA_MAX_DIM - s_ndim + i) % CATERVA_MAX_DIM] = array->shape[i];
     }
-    for (int j = 0; j < CATERVA_MAXDIM - s_ndim; ++j) {
+    for (int j = 0; j < CATERVA_MAX_DIM - s_ndim; ++j) {
         start_[j] = 0;
         stop_[j] = 1;
         d_shape[j] = 1;
 
     }
-    int64_t jj[CATERVA_MAXDIM];
+    int64_t jj[CATERVA_MAX_DIM];
     jj[7] = start_[7];
     for (jj[0] = start_[0]; jj[0] < stop_[0]; ++jj[0]) {
         for (jj[1] = start_[1]; jj[1] < stop_[1]; ++jj[1]) {
@@ -156,13 +157,13 @@ int caterva_plainbuffer_array_set_slice_buffer(caterva_context_t *ctx, void *buf
                             for (jj[6] = start_[6]; jj[6] < stop_[6]; ++jj[6]) {
                                 int64_t chunk_pointer = 0;
                                 int64_t chunk_pointer_inc = 1;
-                                for (int i = CATERVA_MAXDIM - 1; i >= 0; --i) {
+                                for (int i = CATERVA_MAX_DIM - 1; i >= 0; --i) {
                                     chunk_pointer += jj[i] * chunk_pointer_inc;
                                     chunk_pointer_inc *= s_shape[i];
                                 }
                                 int64_t buf_pointer = 0;
                                 int64_t buf_pointer_inc = 1;
-                                for (int i = CATERVA_MAXDIM - 1; i >= 0; --i) {
+                                for (int i = CATERVA_MAX_DIM - 1; i >= 0; --i) {
                                     buf_pointer += (jj[i] - start_[i]) * buf_pointer_inc;
                                     buf_pointer_inc *= d_shape[i];
                                 }
@@ -203,7 +204,7 @@ int caterva_plainbuffer_update_shape(caterva_array_t *array, int8_t ndim, int64_
     array->size = 1;
     array->extendedsize = 1;
     array->chunksize = 1;
-    for (int i = 0; i < CATERVA_MAXDIM; ++i) {
+    for (int i = 0; i < CATERVA_MAX_DIM; ++i) {
         if (i < ndim) {
             array->shape[i] = shape[i];
             array->extendedshape[i] = shape[i];
@@ -226,7 +227,7 @@ int caterva_plainbuffer_array_squeeze(caterva_context_t *ctx, caterva_array_t *a
     CATERVA_UNUSED_PARAM(ctx);
 
     uint8_t nones = 0;
-    int64_t newshape[CATERVA_MAXDIM];
+    int64_t newshape[CATERVA_MAX_DIM];
     for (int i = 0; i < array->ndim; ++i) {
         if (array->shape[i] != 1) {
             newshape[nones] = array->shape[i];
@@ -282,7 +283,7 @@ int caterva_plainbuffer_array_empty(caterva_context_t *ctx, caterva_params_t *pa
         (*array)->extendedsize *= shape[i];
     }
 
-    for (int i = params->ndim; i < CATERVA_MAXDIM; ++i) {
+    for (int i = params->ndim; i < CATERVA_MAX_DIM; ++i) {
         (*array)->shape[i] = 1;
         (*array)->chunkshape[i] = 1;
         (*array)->extendedshape[i] = 1;

--- a/tests/test_append.c
+++ b/tests/test_append.c
@@ -22,7 +22,7 @@ static void test_append_2(caterva_context_t *ctx, uint8_t itemsize, uint8_t ndim
         params.shape[i] = shape[i];
     }
 
-    caterva_storage_t storage;
+    caterva_storage_t storage = {0};
     storage.backend = backend;
     switch (backend) {
         case CATERVA_STORAGE_PLAINBUFFER:

--- a/tests/test_append.c
+++ b/tests/test_append.c
@@ -70,7 +70,7 @@ static void test_append_2(caterva_context_t *ctx, uint8_t itemsize, uint8_t ndim
     uint8_t *buffer_dest = ctx->cfg->alloc(buffersize);
     CATERVA_TEST_ERROR(caterva_array_to_buffer(ctx, src, buffer_dest, buffersize));
 
-    assert_buf(buffer_dest, result, src->itemsize,(size_t)10, 1e-14);
+    assert_buf(buffer_dest, (const uint8_t *) result, src->itemsize, (size_t)10, 1e-14);
     ctx->cfg->free(buffer_dest);
 
     /* Free array  */

--- a/tests/test_append.c
+++ b/tests/test_append.c
@@ -58,6 +58,12 @@ static void test_append(caterva_context_t *ctx, uint8_t itemsize, uint8_t ndim, 
         }
         for (int i = 0; i < nextsize; ++i) {
             switch (src->itemsize) {
+                case 1:
+                    ((uint8_t *) buffer)[i] = (uint8_t) ind;
+                    break;
+                case 2:
+                    ((uint16_t *) buffer)[i] = (uint16_t) ind;
+                    break;
                 case 4:
                     ((float *) buffer)[i] = (float) ind;
                     break;
@@ -79,7 +85,7 @@ static void test_append(caterva_context_t *ctx, uint8_t itemsize, uint8_t ndim, 
     uint8_t *buffer_dest = ctx->cfg->alloc(buffersize);
     CATERVA_TEST_ERROR(caterva_array_to_buffer(ctx, src, buffer_dest, buffersize));
 
-    assert_buf(buffer_dest, (const uint8_t *) result, src->itemsize, (size_t)10, 1e-14);
+    assert_buf((const uint8_t *) buffer_dest, (const uint8_t *) result, src->itemsize, (size_t)10, 1e-14);
     ctx->cfg->free(buffer_dest);
 
     /* Free array  */
@@ -100,7 +106,7 @@ LWTEST_TEARDOWN(append) {
     caterva_context_free(&data->ctx);
 }
 
-LWTEST_FIXTURE(append, 2_dim_pad_sp) {
+LWTEST_FIXTURE(append, 2_dim) {
     uint8_t itemsize = sizeof(double);
     uint8_t ndim = 2;
     int64_t shape_[] = {8, 8};
@@ -158,7 +164,7 @@ LWTEST_FIXTURE(append, 4_dim) {
 }
 
 
-LWTEST_FIXTURE(append, 5_dim) {
+LWTEST_FIXTURE(append, 5_dim_float) {
     uint8_t itemsize = sizeof(float);
     const uint8_t ndim = 5;
     int64_t shape_[] = {14, 23, 12, 11, 8};
@@ -186,7 +192,7 @@ LWTEST_FIXTURE(append, 6_dim) {
     test_append(data->ctx, itemsize, ndim, shape_, backend, pshape_, spshape_, enforceframe, filename, result);
 }
 
-LWTEST_FIXTURE(append, 7_dim) {
+LWTEST_FIXTURE(append, 7_dim_float) {
     uint8_t itemsize = sizeof(float);
     const uint8_t ndim = 7;
     int64_t shape_[] = {5, 3, 2, 4, 3, 2, 7};
@@ -195,6 +201,34 @@ LWTEST_FIXTURE(append, 7_dim) {
     int64_t pshape_[] = {5, 2, 2, 3, 2, 2, 3};
     int64_t spshape_[] = {4, 2, 1, 2, 1, 2, 2};
     float result[80] = {0,1,2,720,721,722,1440,3,4,5};
+    bool enforceframe = false;
+    char *filename = NULL;
+    test_append(data->ctx, itemsize, ndim, shape_, backend, pshape_, spshape_, enforceframe, filename, result);
+}
+
+LWTEST_FIXTURE(append, 8_dim_uint8) {
+    uint8_t itemsize = sizeof(uint8_t);
+    const uint8_t ndim = 8;
+    int64_t shape_[] = {5, 3, 2, 1, 4, 3, 2, 7};
+    caterva_storage_backend_t backend = CATERVA_STORAGE_BLOSC;
+
+    int64_t pshape_[] = {2, 2, 2, 1, 3, 1, 2, 4};
+    int64_t spshape_[] = {2, 2, 2, 1, 3, 1, 2, 4};
+    uint8_t result[80] = {0, 1, 2, 3, 192, 193, 194, 4, 5, 6};
+    bool enforceframe = false;
+    char *filename = NULL;
+    test_append(data->ctx, itemsize, ndim, shape_, backend, pshape_, spshape_, enforceframe, filename, result);
+}
+
+LWTEST_FIXTURE(append, 8_dim_uint16) {
+    uint8_t itemsize = sizeof(uint16_t);
+    const uint8_t ndim = 8;
+    int64_t shape_[] = {5, 3, 2, 3, 4, 3, 3, 7};
+    caterva_storage_backend_t backend = CATERVA_STORAGE_BLOSC;
+
+    int64_t pshape_[] = {2, 3, 2, 2, 3, 1, 2, 4};
+    int64_t spshape_[] = {2, 2, 2, 2, 2, 1, 2, 4};
+    uint16_t result[80] = {0, 1, 2, 3, 576, 577, 578, 4, 5, 6};
     bool enforceframe = false;
     char *filename = NULL;
     test_append(data->ctx, itemsize, ndim, shape_, backend, pshape_, spshape_, enforceframe, filename, result);

--- a/tests/test_append.c
+++ b/tests/test_append.c
@@ -47,37 +47,38 @@ static void test_append_2(caterva_context_t *ctx, uint8_t itemsize, uint8_t ndim
     uint8_t *buffer = malloc(buffersize);
     int ind = 0;
     while (!src->filled) {
-        for (int i = 0; i < src->chunksize; ++i) {
+        memset(buffer, 0, buffersize);
+        for (int i = 0; i < src->next_chunksize; ++i) {
             switch (src->itemsize) {
                 case 4:
-                    ((float *) buffer)[i] = (float) i;
+                    ((float *) buffer)[i] = (float) ind;
                     break;
                 case 8:
-                    ((double *) buffer)[i] = (double) i;
+                    ((double *) buffer)[i] = (double) ind;
                     break;
                 default:
                     CATERVA_TEST_ERROR(CATERVA_ERR_INVALID_STORAGE);
             }
+            ind ++;
         }
         printf("\n buffer to append: \n");
-        for(int i=0; i<src->chunksize; i++) {
+        for(int i=0; i<src->next_chunksize; i++) {
             printf("%f, ", ((double*) buffer)[i]);
         }
-        CATERVA_TEST_ERROR(caterva_array_append(ctx, src, buffer, buffersize));
-        ind++;
+        CATERVA_TEST_ERROR(caterva_array_append(ctx, src, buffer, src->next_chunksize * src->itemsize));
     }
     free(buffer);
 
     /* Fill dest array with caterva_array_t data */
     buffersize = src->size * src->itemsize;
-    buffer = malloc(buffersize);
-    CATERVA_TEST_ERROR(caterva_array_to_buffer(ctx, src, buffer, buffersize));
+    uint8_t *buffer_dest = malloc(buffersize);
+    CATERVA_TEST_ERROR(caterva_array_to_buffer(ctx, src, buffer_dest, buffersize));
     printf("\n to buffer: \n");
     for(int i=0; i<src->size; i++) {
-        printf("%f, ", ((double*) buffer)[i]);
+        printf("%f, ", ((double*) buffer_dest)[i]);
     }
-    assert_buf(buffer, result, src->itemsize,(size_t)10, 1e-14);
-    free(buffer);
+    assert_buf(buffer_dest, result, src->itemsize,(size_t)10, 1e-14);
+    free(buffer_dest);
 
 
     /* Free array  */
@@ -112,34 +113,21 @@ LWTEST_FIXTURE(append_2, 2_dim_pad_sp) {
 
     test_append_2(data->ctx, itemsize, ndim, shape_, backend, chunkshape_, blockshape_, enforceframe, filename, result);
 }
-/*
-LWTEST_FIXTURE(append_2, 2_dim) {
-    uint8_t itemsize = sizeof(double);
-    const uint8_t ndim = 2;
-    int64_t shape_[] = {10, 10};
-    caterva_storage_backend_t backend = CATERVA_STORAGE_BLOSC;
-
-    int64_t pshape_[] = {3, 3};
-    int64_t spshape_[] = {2, 2};
-    double result[80] = {0,1,2,9,10,11,18,19,20,27};
-    bool enforceframe = false;
-    char *filename = NULL;
-    test_append_2(data->ctx, itemsize, ndim, shape_, backend, pshape_, spshape_, enforceframe, filename, result);
-}
 
 LWTEST_FIXTURE(append_2, 3_dim) {
     uint8_t itemsize = sizeof(double);
     const uint8_t ndim = 3;
-    int64_t shape_[] = {4, 3, 3};
+    int64_t shape_[] = {4, 4, 5};
 
     caterva_storage_backend_t backend = CATERVA_STORAGE_BLOSC;
-    int64_t pshape_[] = {2, 2, 2};
-    int64_t spshape_[] = {1, 1, 1};
-    double result[80] = {0,1,8,2,3,9,12,13,16,4};
+    int64_t pshape_[] = {3, 3, 4};
+    int64_t spshape_[] = {3, 2, 3};
+    double result[80] = {0,1,2,3,36,4,5,6,7,37};
     bool enforceframe = false;
     char *filename = NULL;
     test_append_2(data->ctx, itemsize, ndim, shape_, backend, pshape_, spshape_, enforceframe, filename, result);
 }
+
 
 LWTEST_FIXTURE(append_2, 4_dim) {
     uint8_t itemsize = sizeof(double);
@@ -148,12 +136,13 @@ LWTEST_FIXTURE(append_2, 4_dim) {
     caterva_storage_backend_t backend = CATERVA_STORAGE_BLOSC;
 
     int64_t pshape_[] = {2, 3, 2, 3};
-    int64_t spshape_[] = {1, 2, 1, 1};
+    int64_t spshape_[] = {2, 3, 1, 3};
     double result[80] = {0,1,2,36,37,38,3,4,5,39};
     bool enforceframe = false;
     char *filename = NULL;
     test_append_2(data->ctx, itemsize, ndim, shape_, backend, pshape_, spshape_, enforceframe, filename, result);
 }
+
 
 LWTEST_FIXTURE(append_2, 5_dim) {
     uint8_t itemsize = sizeof(double);
@@ -168,4 +157,3 @@ LWTEST_FIXTURE(append_2, 5_dim) {
     char *filename = NULL;
     test_append_2(data->ctx, itemsize, ndim, shape_, backend, pshape_, spshape_, enforceframe, filename, result);
 }
-*/

--- a/tests/test_append.c
+++ b/tests/test_append.c
@@ -44,7 +44,7 @@ static void test_append_2(caterva_context_t *ctx, uint8_t itemsize, uint8_t ndim
 
     /* Fill empty caterva_array_t with blocks */
     int64_t buffersize = src->chunksize * src->itemsize;
-    uint8_t *buffer = malloc(buffersize);
+    uint8_t *buffer = ctx->cfg->alloc(buffersize);
     int ind = 0;
     while (!src->filled) {
         memset(buffer, 0, buffersize);
@@ -61,25 +61,17 @@ static void test_append_2(caterva_context_t *ctx, uint8_t itemsize, uint8_t ndim
             }
             ind ++;
         }
-        printf("\n buffer to append: \n");
-        for(int i=0; i<src->next_chunksize; i++) {
-            printf("%f, ", ((double*) buffer)[i]);
-        }
         CATERVA_TEST_ERROR(caterva_array_append(ctx, src, buffer, src->next_chunksize * src->itemsize));
     }
-    free(buffer);
+    ctx->cfg->free(buffer);
 
     /* Fill dest array with caterva_array_t data */
     buffersize = src->size * src->itemsize;
-    uint8_t *buffer_dest = malloc(buffersize);
+    uint8_t *buffer_dest = ctx->cfg->alloc(buffersize);
     CATERVA_TEST_ERROR(caterva_array_to_buffer(ctx, src, buffer_dest, buffersize));
-    printf("\n to buffer: \n");
-    for(int i=0; i<src->size; i++) {
-        printf("%f, ", ((double*) buffer_dest)[i]);
-    }
-    assert_buf(buffer_dest, result, src->itemsize,(size_t)10, 1e-14);
-    free(buffer_dest);
 
+    assert_buf(buffer_dest, result, src->itemsize,(size_t)10, 1e-14);
+    ctx->cfg->free(buffer_dest);
 
     /* Free array  */
     CATERVA_TEST_ERROR(caterva_array_free(ctx, &src));

--- a/tests/test_append.c
+++ b/tests/test_append.c
@@ -13,7 +13,7 @@
 
 static void test_append(caterva_context_t *ctx, uint8_t itemsize, uint8_t ndim, int64_t *shape,
                           caterva_storage_backend_t backend, int64_t *chunkshape, int64_t *blockshape, bool enforceframe,
-                          char *filename, double *result) {
+                          char *filename, void *result) {
 
     caterva_params_t params;
     params.itemsize = itemsize;

--- a/tests/test_common.h
+++ b/tests/test_common.h
@@ -31,6 +31,16 @@ static void fill_buf(uint8_t *buf, uint8_t itemsize, size_t buf_size) {
                 ((float *) buf)[i] = (float) i;
             }
             break;
+        case 2:
+            for (size_t i = 0; i < buf_size; ++i) {
+                ((uint16_t *) buf)[i] = (uint16_t ) i;
+            }
+            break;
+        case 1:
+            for (size_t i = 0; i < buf_size; ++i) {
+                ((uint8_t *) buf)[i] = (uint8_t ) i;
+            }
+            break;
         default:CATERVA_TEST_ERROR(CATERVA_ERR_INVALID_ARGUMENT);
     }
 }
@@ -49,6 +59,20 @@ static void assert_buf(const uint8_t *exp, const uint8_t *real, uint8_t itemsize
             for (size_t i = 0; i < size; ++i) {
                 double a = ((float *) exp)[i];
                 double b = ((float *) real)[i];
+                LWTEST_ASSERT_ALMOST_EQUAL_DOUBLE(a, b, tol);
+            }
+            break;
+        case 2:
+            for (size_t i = 0; i < size; ++i) {
+                double a = ((uint16_t *) exp)[i];
+                double b = ((uint16_t *) real)[i];
+                LWTEST_ASSERT_ALMOST_EQUAL_DOUBLE(a, b, tol);
+            }
+            break;
+        case 1:
+            for (size_t i = 0; i < size; ++i) {
+                double a = ((uint8_t *) exp)[i];
+                double b = ((uint8_t *) real)[i];
                 LWTEST_ASSERT_ALMOST_EQUAL_DOUBLE(a, b, tol);
             }
             break;

--- a/tests/test_copy.c
+++ b/tests/test_copy.c
@@ -22,9 +22,7 @@ static void test_copy(caterva_context_t *ctx, uint8_t itemsize, uint8_t ndim, in
         params.shape[i] = shape[i];
     }
 
-    double datatoserialize = 8.34;
-
-    caterva_storage_t storage = {0};
+    caterva_storage_t storage;
     storage.backend = backend;
     switch (backend) {
         case CATERVA_STORAGE_PLAINBUFFER:
@@ -35,11 +33,6 @@ static void test_copy(caterva_context_t *ctx, uint8_t itemsize, uint8_t ndim, in
             for (int i = 0; i < ndim; ++i) {
                 storage.properties.blosc.chunkshape[i] = chunkshape[i];
             }
-            storage.properties.blosc.nmetalayers = 1;
-            storage.properties.blosc.metalayers[0].name = "random";
-            storage.properties.blosc.metalayers[0].sdata = (uint8_t *) &datatoserialize;
-            storage.properties.blosc.metalayers[0].size = 8;
-
             break;
         default:
             CATERVA_TEST_ERROR(CATERVA_ERR_INVALID_STORAGE);
@@ -57,22 +50,10 @@ static void test_copy(caterva_context_t *ctx, uint8_t itemsize, uint8_t ndim, in
     caterva_array_t *src;
     CATERVA_TEST_ERROR(caterva_array_from_buffer(ctx, buffer, buffersize, &params, &storage, &src));
 
-    /* Assert the metalayers creation */
-    if (storage.backend == CATERVA_STORAGE_BLOSC) {
-        if (blosc2_has_metalayer(src->sc, "random") < 0) {
-            CATERVA_TEST_ERROR(CATERVA_ERR_BLOSC_FAILED);
-        }
-        double *serializeddata;
-        uint32_t len;
-        blosc2_get_metalayer(src->sc, "random", (uint8_t **) &serializeddata, &len);
-        if (*serializeddata != datatoserialize) {
-           CATERVA_TEST_ERROR(CATERVA_ERR_BLOSC_FAILED);
-        }
-        free(serializeddata);
-    }
 
     /* Create storage for dest container */
-    caterva_storage_t storage2 = {0};
+
+    caterva_storage_t storage2;
     storage2.backend = backend2;
     switch (backend2) {
         case CATERVA_STORAGE_PLAINBUFFER:

--- a/tests/test_copy.c
+++ b/tests/test_copy.c
@@ -121,6 +121,27 @@ LWTEST_TEARDOWN(copy) {
     caterva_context_free(&data->ctx);
 }
 
+LWTEST_FIXTURE(copy, 1_double_plain_blosc) {
+    uint8_t itemsize = sizeof(double);
+    uint8_t ndim = 1;
+    int64_t shape[] = {17};
+
+    caterva_storage_backend_t backend = CATERVA_STORAGE_PLAINBUFFER;
+    int64_t chunkshape[] = {0};
+    int64_t blockshape[] = {0};
+    bool enforceframe = false;
+    char *filename = NULL;
+
+    caterva_storage_backend_t backend2 = CATERVA_STORAGE_BLOSC;
+    int64_t chunkshape2[] = {14};
+    int64_t blockshape2[] = {13};
+    bool enforceframe2 = false;
+    char *filename2 = NULL;
+
+    test_copy(data->ctx, itemsize, ndim, shape, backend, chunkshape, blockshape, enforceframe,
+              filename, backend2, chunkshape2, blockshape2, enforceframe2, filename2);
+}
+
 LWTEST_FIXTURE(copy, 2_double_blosc_blosc) {
     uint8_t itemsize = sizeof(double);
     uint8_t ndim = 2;
@@ -208,8 +229,8 @@ LWTEST_FIXTURE(copy, 5_double_plainbuffer_plainbuffer) {
             filename, backend2, chunkshape2, blockshape2, enforceframe2, filename2);
 }
 
-LWTEST_FIXTURE(copy, 6_float_blosc_plainbuffer) {
-    uint8_t itemsize = sizeof(float);
+LWTEST_FIXTURE(copy, 6_uint16_blosc_plainbuffer) {
+    uint8_t itemsize = sizeof(uint16_t);
     uint8_t ndim = 6;
     int64_t shape[] = {4, 3, 8, 5, 6, 5};
 
@@ -229,8 +250,8 @@ LWTEST_FIXTURE(copy, 6_float_blosc_plainbuffer) {
               filename, backend2, chunkshape2, blockshape2, enforceframe2, filename2);
 }
 
-LWTEST_FIXTURE(copy, 7_double_blosc_blosc) {
-    uint8_t itemsize = sizeof(double);
+LWTEST_FIXTURE(copy, 7_float_blosc_blosc) {
+    uint8_t itemsize = sizeof(float);
     uint8_t ndim = 7;
     int64_t shape[] = {2, 3, 5, 3, 4, 1, 4};
 
@@ -250,8 +271,8 @@ LWTEST_FIXTURE(copy, 7_double_blosc_blosc) {
               filename, backend2, chunkshape2, blockshape2, enforceframe2, filename2);
 }
 
-LWTEST_FIXTURE(copy, 8_double_plainbuffer_plainbuffer) {
-    uint8_t itemsize = sizeof(double);
+LWTEST_FIXTURE(copy, 8_uint8_plainbuffer_plainbuffer) {
+    uint8_t itemsize = sizeof(uint8_t);
     uint8_t ndim = 8;
     int64_t shape[] = {4, 3, 6, 8, 2, 5, 9, 3};
 

--- a/tests/test_copy.c
+++ b/tests/test_copy.c
@@ -143,7 +143,7 @@ LWTEST_FIXTURE(copy, 2_double_blosc_blosc) {
 }
 
 
-LWTEST_FIXTURE(copy, 3_float_blosc_plainbuffer) {
+LWTEST_FIXTURE(copy, 3_double_blosc_plainbuffer) {
     uint8_t itemsize = sizeof(double);
     uint8_t ndim = 3;
     int64_t shape[] = {134, 56, 204};
@@ -187,7 +187,7 @@ LWTEST_FIXTURE(copy, 4_float_plainbuffer_blosc_frame) {
 }
 
 
-LWTEST_FIXTURE(copy, 5_float_plainbuffer_plainbuffer) {
+LWTEST_FIXTURE(copy, 5_double_plainbuffer_plainbuffer) {
     uint8_t itemsize = sizeof(double);
     uint8_t ndim = 5;
     int64_t shape[] = {4, 3, 8, 5, 10};
@@ -208,3 +208,65 @@ LWTEST_FIXTURE(copy, 5_float_plainbuffer_plainbuffer) {
             filename, backend2, chunkshape2, blockshape2, enforceframe2, filename2);
 }
 
+LWTEST_FIXTURE(copy, 6_float_blosc_plainbuffer) {
+    uint8_t itemsize = sizeof(float);
+    uint8_t ndim = 6;
+    int64_t shape[] = {4, 3, 8, 5, 6, 5};
+
+    caterva_storage_backend_t backend = CATERVA_STORAGE_BLOSC;
+    int64_t chunkshape[] = {3, 2, 5, 3, 5, 4};
+    int64_t blockshape[] = {2, 1, 3, 2, 2, 3};
+    bool enforceframe = false;
+    char *filename = NULL;
+
+    caterva_storage_backend_t backend2 = CATERVA_STORAGE_PLAINBUFFER;
+    int64_t chunkshape2[] = {0};
+    int64_t blockshape2[] = {0};
+    bool enforceframe2 = false;
+    char *filename2 = NULL;
+
+    test_copy(data->ctx, itemsize, ndim, shape, backend, chunkshape, blockshape, enforceframe,
+              filename, backend2, chunkshape2, blockshape2, enforceframe2, filename2);
+}
+
+LWTEST_FIXTURE(copy, 7_double_blosc_blosc) {
+    uint8_t itemsize = sizeof(double);
+    uint8_t ndim = 7;
+    int64_t shape[] = {2, 3, 5, 3, 4, 1, 4};
+
+    caterva_storage_backend_t backend = CATERVA_STORAGE_BLOSC;
+    int64_t chunkshape[] = {1, 2, 4, 2, 3, 1, 3};
+    int64_t blockshape[] = {1, 1, 3, 2, 2, 1, 3};
+    bool enforceframe = false;
+    char *filename = NULL;
+
+    caterva_storage_backend_t backend2 = CATERVA_STORAGE_BLOSC;
+    int64_t chunkshape2[] = {2, 1, 5, 3, 3, 1, 3};
+    int64_t blockshape2[] = {2, 1, 4, 1, 2, 1, 2};
+    bool enforceframe2 = false;
+    char *filename2 = NULL;
+
+    test_copy(data->ctx, itemsize, ndim, shape, backend, chunkshape, blockshape, enforceframe,
+              filename, backend2, chunkshape2, blockshape2, enforceframe2, filename2);
+}
+
+LWTEST_FIXTURE(copy, 8_double_plainbuffer_plainbuffer) {
+    uint8_t itemsize = sizeof(double);
+    uint8_t ndim = 8;
+    int64_t shape[] = {4, 3, 6, 8, 2, 5, 9, 3};
+
+    caterva_storage_backend_t backend = CATERVA_STORAGE_PLAINBUFFER;
+    int64_t chunkshape[] = {0};
+    int64_t blockshape[] = {0};
+    bool enforceframe = false;
+    char *filename = NULL;
+
+    caterva_storage_backend_t backend2 = CATERVA_STORAGE_PLAINBUFFER;
+    int64_t chunkshape2[] = {0};
+    int64_t blockshape2[] = {0};
+    bool enforceframe2 = false;
+    char *filename2 = NULL;
+
+    test_copy(data->ctx, itemsize, ndim, shape, backend, chunkshape, blockshape, enforceframe,
+              filename, backend2, chunkshape2, blockshape2, enforceframe2, filename2);
+}

--- a/tests/test_copy.c
+++ b/tests/test_copy.c
@@ -12,8 +12,9 @@
 #include "test_common.h"
 
 static void test_copy(caterva_context_t *ctx, uint8_t itemsize, uint8_t ndim, int64_t *shape,
-                      caterva_storage_backend_t backend, int64_t *chunkshape, bool enforceframe, char *filename,
-                      caterva_storage_backend_t backend2, int64_t *chunkshape2, bool enforceframe2, char *filename2) {
+                      caterva_storage_backend_t backend, int64_t *chunkshape, int64_t *blockshape,
+                      bool enforceframe, char *filename, caterva_storage_backend_t backend2,
+                      int64_t *chunkshape2, int64_t *blockshape2, bool enforceframe2, char *filename2) {
 
     caterva_params_t params;
     params.itemsize = itemsize;
@@ -34,6 +35,7 @@ static void test_copy(caterva_context_t *ctx, uint8_t itemsize, uint8_t ndim, in
             storage.properties.blosc.enforceframe = enforceframe;
             for (int i = 0; i < ndim; ++i) {
                 storage.properties.blosc.chunkshape[i] = chunkshape[i];
+                storage.properties.blosc.blockshape[i] = blockshape[i];
             }
             storage.properties.blosc.nmetalayers = 1;
             storage.properties.blosc.metalayers[0].name = "random";
@@ -82,6 +84,7 @@ static void test_copy(caterva_context_t *ctx, uint8_t itemsize, uint8_t ndim, in
             storage2.properties.blosc.enforceframe = enforceframe2;
             for (int i = 0; i < ndim; ++i) {
                 storage2.properties.blosc.chunkshape[i] = chunkshape2[i];
+                storage2.properties.blosc.blockshape[i] = blockshape2[i];
             }
             break;
         default:
@@ -125,16 +128,18 @@ LWTEST_FIXTURE(copy, 2_double_blosc_blosc) {
 
     caterva_storage_backend_t backend = CATERVA_STORAGE_BLOSC;
     int64_t chunkshape[] = {26, 17};
+    int64_t blockshape[] = {15, 12};
     bool enforceframe = false;
     char *filename = NULL;
 
     caterva_storage_backend_t backend2 = CATERVA_STORAGE_BLOSC;
     int64_t chunkshape2[] = {14, 24};
+    int64_t blockshape2[] = {7, 11};
     bool enforceframe2 = false;
     char *filename2 = NULL;
 
-    test_copy(data->ctx, itemsize, ndim, shape, backend, chunkshape, enforceframe, filename, backend2,
-              chunkshape2, enforceframe2, filename2);
+    test_copy(data->ctx, itemsize, ndim, shape, backend, chunkshape, blockshape, enforceframe,
+            filename, backend2, chunkshape2, blockshape2, enforceframe2, filename2);
 }
 
 
@@ -145,16 +150,18 @@ LWTEST_FIXTURE(copy, 3_float_blosc_plainbuffer) {
 
     caterva_storage_backend_t backend = CATERVA_STORAGE_BLOSC;
     int64_t chunkshape[] = {26, 17, 34};
+    int64_t blockshape[] = {11, 8, 12};
     bool enforceframe = false;
     char *filename = NULL;
 
     caterva_storage_backend_t backend2 = CATERVA_STORAGE_PLAINBUFFER;
     int64_t chunkshape2[] = {0};
+    int64_t blockshape2[] = {0};
     bool enforceframe2 = false;
     char *filename2 = NULL;
 
-    test_copy(data->ctx, itemsize, ndim, shape, backend, chunkshape, enforceframe, filename, backend2,
-              chunkshape2, enforceframe2, filename2);
+    test_copy(data->ctx, itemsize, ndim, shape, backend, chunkshape, blockshape, enforceframe,
+            filename, backend2, chunkshape2, blockshape2, enforceframe2, filename2);
 }
 
 
@@ -165,16 +172,18 @@ LWTEST_FIXTURE(copy, 4_float_plainbuffer_blosc_frame) {
 
     caterva_storage_backend_t backend = CATERVA_STORAGE_PLAINBUFFER;
     int64_t chunkshape[] = {0};
+    int64_t blockshape[] = {0};
     bool enforceframe = false;
     char *filename = NULL;
 
     caterva_storage_backend_t backend2 = CATERVA_STORAGE_BLOSC;
     int64_t chunkshape2[] = {2, 2, 3, 2};
+    int64_t blockshape2[] = {2, 2, 2, 2};
     bool enforceframe2 = true;
     char *filename2 = NULL;
 
-    test_copy(data->ctx, itemsize, ndim, shape, backend, chunkshape, enforceframe, filename, backend2,
-              chunkshape2, enforceframe2, filename2);
+    test_copy(data->ctx, itemsize, ndim, shape, backend, chunkshape, blockshape, enforceframe,
+            filename, backend2, chunkshape2, blockshape2, enforceframe2, filename2);
 }
 
 
@@ -185,15 +194,17 @@ LWTEST_FIXTURE(copy, 5_float_plainbuffer_plainbuffer) {
 
     caterva_storage_backend_t backend = CATERVA_STORAGE_PLAINBUFFER;
     int64_t chunkshape[] = {0};
+    int64_t blockshape[] = {0};
     bool enforceframe = false;
     char *filename = NULL;
 
     caterva_storage_backend_t backend2 = CATERVA_STORAGE_PLAINBUFFER;
     int64_t chunkshape2[] = {0};
+    int64_t blockshape2[] = {0};
     bool enforceframe2 = false;
     char *filename2 = NULL;
 
-    test_copy(data->ctx, itemsize, ndim, shape, backend, chunkshape, enforceframe, filename, backend2,
-              chunkshape2, enforceframe2, filename2);
+    test_copy(data->ctx, itemsize, ndim, shape, backend, chunkshape, blockshape, enforceframe,
+            filename, backend2, chunkshape2, blockshape2, enforceframe2, filename2);
 }
 

--- a/tests/test_get_slice.c
+++ b/tests/test_get_slice.c
@@ -48,10 +48,21 @@ static void test_get_slice(caterva_context_t *ctx, uint8_t itemsize, uint8_t ndi
     uint8_t *buffer = ctx->cfg->alloc(buffersize);
     // fill_buf(buffer, itemsize, buffersize / itemsize);
     for (int i = 0; i < (buffersize/itemsize); ++i) {
-        if (itemsize == 4) {
-            ((float *) buffer)[i] = (float) i;
-        } else {
-            ((double *) buffer)[i] = (double) i;
+        switch (itemsize) {
+            case 1:
+                ((uint8_t *) buffer)[i] = (uint8_t) i;
+                break;
+            case 2:
+                ((uint16_t *) buffer)[i] = (uint16_t) i;
+                break;
+            case 4:
+                ((float *) buffer)[i] = (float) i;
+                break;
+            case 8:
+                ((double *) buffer)[i] = (double) i;
+                break;
+            default:
+                CATERVA_TEST_ERROR(CATERVA_ERR_INVALID_STORAGE);
         }
     }
 
@@ -142,16 +153,16 @@ LWTEST_FIXTURE(get_slice, 1_double_plainbuffer_plainbuffer) {
 }
 
 
-LWTEST_FIXTURE(get_slice, 2_double_plainbuffer_blosc) {
+LWTEST_FIXTURE(get_slice, 2_uint16_plainbuffer_blosc) {
     int64_t start[] = {5, 3};
     int64_t stop[] = {9, 10};
 
-    float result[1024] = {53, 54, 55, 56, 57, 58, 59, 63, 64, 65, 66, 67, 68, 69, 73, 74, 75, 76,
+    uint16_t result[1024] = {53, 54, 55, 56, 57, 58, 59, 63, 64, 65, 66, 67, 68, 69, 73, 74, 75, 76,
                            77, 78, 79, 83, 84, 85, 86, 87, 88, 89};
 
-    uint8_t itemsize = sizeof(float);
+    uint8_t itemsize = sizeof(uint16_t);
     uint8_t ndim = 2;
-    int64_t shape[] = {10, 10};
+    int64_t shape[] = {14, 10};
 
     caterva_storage_backend_t backend = CATERVA_STORAGE_PLAINBUFFER;
     int64_t chunkshape[] = {0};
@@ -160,13 +171,39 @@ LWTEST_FIXTURE(get_slice, 2_double_plainbuffer_blosc) {
     char *filename = NULL;
 
     caterva_storage_backend_t backend2 = CATERVA_STORAGE_BLOSC;
-    int64_t chunkshape2[] = {3, 5};
-    int64_t blockshape2[] = {3, 5};
+    int64_t chunkshape2[] = {10, 9};
+    int64_t blockshape2[] = {9, 9};
     bool enforceframe2 = false;
     char *filename2 = NULL;
 
     test_get_slice(data->ctx, itemsize, ndim, shape, backend, chunkshape, blockshape, enforceframe, filename,
         backend2, chunkshape2, blockshape2, enforceframe2, filename2, start, stop, result);
+}
+
+LWTEST_FIXTURE(get_slice, 2_uint8_plainbuffer_plainbuffer) {
+    int64_t start[] = {5, 7};
+    int64_t stop[] = {8, 8};
+
+    uint8_t result[1024] = {57, 67, 77, 87};
+
+    uint8_t itemsize = sizeof(uint8_t);
+    uint8_t ndim = 2;
+    int64_t shape[] = {14, 10};
+
+    caterva_storage_backend_t backend = CATERVA_STORAGE_PLAINBUFFER;
+    int64_t chunkshape[] = {0};
+    int64_t blockshape[] = {0};
+    bool enforceframe = false;
+    char *filename = NULL;
+
+    caterva_storage_backend_t backend2 = CATERVA_STORAGE_PLAINBUFFER;
+    int64_t chunkshape2[] = {0};
+    int64_t blockshape2[] = {0};
+    bool enforceframe2 = false;
+    char *filename2 = NULL;
+
+    test_get_slice(data->ctx, itemsize, ndim, shape, backend, chunkshape, blockshape, enforceframe, filename,
+                   backend2, chunkshape2, blockshape2, enforceframe2, filename2, start, stop, result);
 }
 
 LWTEST_FIXTURE(get_slice, 3_float_blosc_blosc) {
@@ -239,14 +276,14 @@ LWTEST_FIXTURE(get_slice, 5_float_plainbuffer_plainbuffer) {
     int64_t start[] = {6, 0, 5, 5, 7};
     int64_t stop[] = {8, 9, 6, 6, 10};
 
-    double result[1024] = {60557, 60558, 60559, 61557, 61558, 61559, 62557, 62558, 62559, 63557,
+    float result[1024] = {60557, 60558, 60559, 61557, 61558, 61559, 62557, 62558, 62559, 63557,
                           63558, 63559, 64557, 64558, 64559, 65557, 65558, 65559, 66557, 66558,
                           66559, 67557, 67558, 67559, 68557, 68558, 68559, 70557, 70558, 70559,
                           71557, 71558, 71559, 72557, 72558, 72559, 73557, 73558, 73559, 74557,
                           74558, 74559, 75557, 75558, 75559, 76557, 76558, 76559, 77557, 77558,
                           77559, 78557, 78558, 78559};
 
-    uint8_t itemsize = sizeof(double);
+    uint8_t itemsize = sizeof(float );
     uint8_t ndim = 5;
     int64_t shape[] = {10, 10, 10, 10, 10};
 
@@ -304,11 +341,11 @@ LWTEST_FIXTURE(get_slice, 7_float_blosc_frame_plainbuffer) {
     int64_t start[] = {1, 4, 2, 2, 2, 2, 1};
     int64_t stop[] = {4, 5, 3, 4, 3, 5, 2};
 
-    double result[1024] = {4745, 4747, 4749, 4785, 4787, 4789, 7145, 7147, 7149, 7185, 7187,
+    float result[1024] = {4745, 4747, 4749, 4785, 4787, 4789, 7145, 7147, 7149, 7185, 7187,
                           7189, 9545, 9547, 9549, 9585, 9587, 9589};
 
 
-    uint8_t itemsize = sizeof(double);
+    uint8_t itemsize = sizeof(float);
     uint8_t ndim = 7;
     int64_t shape[] = {4, 5, 3, 4, 4, 5, 2};
 
@@ -328,7 +365,7 @@ LWTEST_FIXTURE(get_slice, 7_float_blosc_frame_plainbuffer) {
                    backend2, chunkshape2, blockshape2, enforceframe2, filename2, start, stop, result);
 }
 
-LWTEST_FIXTURE(get_slice, 8_float_blosc_frame_blosc_frame) {
+LWTEST_FIXTURE(get_slice, 8_double_blosc_frame_blosc_frame) {
     int64_t start[] = {3, 2, 2, 2, 2, 1, 1, 1};
     int64_t stop[] = {4, 3, 3, 3, 3, 3, 2, 3};
 

--- a/tests/test_get_slice.c
+++ b/tests/test_get_slice.c
@@ -114,7 +114,7 @@ LWTEST_SETUP(get_slice) {
 LWTEST_TEARDOWN(get_slice) {
     caterva_context_free(&data->ctx);
 }
-/*
+
 LWTEST_FIXTURE(get_slice, 1_double_plainbuffer_plainbuffer) {
     int64_t start[] = {2};
     int64_t stop[] = {9};
@@ -127,18 +127,20 @@ LWTEST_FIXTURE(get_slice, 1_double_plainbuffer_plainbuffer) {
 
     caterva_storage_backend_t backend = CATERVA_STORAGE_PLAINBUFFER;
     int64_t chunkshape[] = {0};
+    int64_t blockshape[] = {0};
     bool enforceframe = false;
     char *filename = NULL;
 
     caterva_storage_backend_t backend2 = CATERVA_STORAGE_PLAINBUFFER;
     int64_t chunkshape2[] = {0};
+    int64_t blockshape2[] = {0};
     bool enforceframe2 = false;
     char *filename2 = NULL;
 
-    test_get_slice(data->ctx, itemsize, ndim, shape, backend, chunkshape, enforceframe, filename,
-                   backend2, chunkshape2, enforceframe2, filename2, start, stop, result);
+    test_get_slice(data->ctx, itemsize, ndim, shape, backend, chunkshape, blockshape, enforceframe, filename,
+                   backend2, chunkshape2, blockshape2, enforceframe2, filename2, start, stop, result);
 }
-*/
+
 
 LWTEST_FIXTURE(get_slice, 2_double_plainbuffer_blosc) {
     int64_t start[] = {5, 3};

--- a/tests/test_get_slice.c
+++ b/tests/test_get_slice.c
@@ -55,7 +55,6 @@ static void test_get_slice(caterva_context_t *ctx, uint8_t itemsize, uint8_t ndi
         }
     }
 
-
     /* Create caterva_array_t with original data */
     caterva_array_t *src;
     CATERVA_TEST_ERROR(caterva_array_from_buffer(ctx, buffer, buffersize, &params, &storage, &src));
@@ -90,14 +89,6 @@ static void test_get_slice(caterva_context_t *ctx, uint8_t itemsize, uint8_t ndi
     uint8_t *buffer_dest = ctx->cfg->alloc(destbuffersize);
     CATERVA_TEST_ERROR(caterva_array_to_buffer(ctx, dest, buffer_dest, destbuffersize));
 
-    printf("\n buffer dest: \n");
-    for (int i = 0; i < (destbuffersize/itemsize); ++i) {
-        if (itemsize == 4) {
-            printf("%f, ", ((float*) buffer_dest)[i] );
-        } else {
-            printf("%f, ", ((double*) buffer_dest)[i] );
-        }
-    }
     /* Testing */
    // double tol = (itemsize == 4) ? 1e-6 : 1e-15;
     double tol = 1e-14;
@@ -148,15 +139,15 @@ LWTEST_FIXTURE(get_slice, 1_double_plainbuffer_plainbuffer) {
                    backend2, chunkshape2, enforceframe2, filename2, start, stop, result);
 }
 */
-/*
+
 LWTEST_FIXTURE(get_slice, 2_double_plainbuffer_blosc) {
     int64_t start[] = {5, 3};
     int64_t stop[] = {9, 10};
 
-    double result[1024] = {53, 54, 55, 56, 57, 58, 59, 63, 64, 65, 66, 67, 68, 69, 73, 74, 75, 76,
+    float result[1024] = {53, 54, 55, 56, 57, 58, 59, 63, 64, 65, 66, 67, 68, 69, 73, 74, 75, 76,
                            77, 78, 79, 83, 84, 85, 86, 87, 88, 89};
 
-    uint8_t itemsize = sizeof(double);
+    uint8_t itemsize = sizeof(float);
     uint8_t ndim = 2;
     int64_t shape[] = {10, 10};
 
@@ -175,7 +166,6 @@ LWTEST_FIXTURE(get_slice, 2_double_plainbuffer_blosc) {
     test_get_slice(data->ctx, itemsize, ndim, shape, backend, chunkshape, blockshape, enforceframe, filename,
         backend2, chunkshape2, blockshape2, enforceframe2, filename2, start, stop, result);
 }
-*/
 
 LWTEST_FIXTURE(get_slice, 3_float_blosc_blosc) {
     int64_t start[] = {3, 0, 3};
@@ -198,32 +188,32 @@ LWTEST_FIXTURE(get_slice, 3_float_blosc_blosc) {
     int64_t shape[] = {10, 10, 10};
 
     caterva_storage_backend_t backend = CATERVA_STORAGE_BLOSC;
-    int64_t chunkshape[] = {3, 5, 2};
-    int64_t blockshape[] = {3, 3, 2};
+    int64_t chunkshape[] = {3, 5, 9};
+    int64_t blockshape[] = {3, 4, 4};
     bool enforceframe = false;
     char *filename = NULL;
 
     caterva_storage_backend_t backend2 = CATERVA_STORAGE_BLOSC;
-    int64_t chunkshape2[] = {2, 4, 3};
-    int64_t blockshape2[] = {2, 3, 3};
+    int64_t chunkshape2[] = {3, 7, 7};
+    int64_t blockshape2[] = {2, 5, 5};
     bool enforceframe2 = false;
     char *filename2 = NULL;
 
     test_get_slice(data->ctx, itemsize, ndim, shape, backend, chunkshape, blockshape, enforceframe, filename,
                    backend2, chunkshape2, blockshape2, enforceframe2, filename2, start, stop, result);
 }
-/*
+
 LWTEST_FIXTURE(get_slice, 4_double_blosc_plainbuffer) {
     int64_t start[] = {5, 3, 9, 2};
     int64_t stop[] = {9, 6, 10, 7};
 
-    double result[1024] = {5392, 5393, 5394, 5395, 5396, 5492, 5493, 5494, 5495, 5496, 5592, 5593,
+    float result[1024] = {5392, 5393, 5394, 5395, 5396, 5492, 5493, 5494, 5495, 5496, 5592, 5593,
                            5594, 5595, 5596, 6392, 6393, 6394, 6395, 6396, 6492, 6493, 6494, 6495,
                            6496, 6592, 6593, 6594, 6595, 6596, 7392, 7393, 7394, 7395, 7396, 7492,
                            7493, 7494, 7495, 7496, 7592, 7593, 7594, 7595, 7596, 8392, 8393, 8394,
                            8395, 8396, 8492, 8493, 8494, 8495, 8496, 8592, 8593, 8594, 8595, 8596};
 
-    uint8_t itemsize = sizeof(double);
+    uint8_t itemsize = sizeof(float);
     uint8_t ndim = 4;
     int64_t shape[] = {10, 10, 10, 10};
 
@@ -279,7 +269,7 @@ LWTEST_FIXTURE(get_slice, 6_double_plainbuffer_blosc_frame) {
     int64_t start[] = {0, 4, 2, 4, 5, 1};
     int64_t stop[] = {1, 7, 4, 6, 8, 3};
 
-    double result[1024] = {42451, 42452, 42461, 42462, 42471, 42472, 42551, 42552, 42561, 42562,
+    float result[1024] = {42451, 42452, 42461, 42462, 42471, 42472, 42551, 42552, 42561, 42562,
                            42571, 42572, 43451, 43452, 43461, 43462, 43471, 43472, 43551, 43552,
                            43561, 43562, 43571, 43572, 52451, 52452, 52461, 52462, 52471, 52472,
                            52551, 52552, 52561, 52562, 52571, 52572, 53451, 53452, 53461, 53462,
@@ -288,7 +278,7 @@ LWTEST_FIXTURE(get_slice, 6_double_plainbuffer_blosc_frame) {
                            63451, 63452, 63461, 63462, 63471, 63472, 63551, 63552, 63561, 63562,
                            63571, 63572};
 
-    uint8_t itemsize = sizeof(double);
+    uint8_t itemsize = sizeof(float);
     uint8_t ndim = 6;
     int64_t shape[] = {10, 10, 10, 10, 10, 10};
 
@@ -360,4 +350,3 @@ LWTEST_FIXTURE(get_slice, 8_float_blosc_frame_blosc_frame) {
 
     test_get_slice(data->ctx, itemsize, ndim, shape, backend, chunkshape, blockshape, enforceframe, filename,
                    backend2, chunkshape2, blockshape2, enforceframe2, filename2, start, stop, result);}
-*/

--- a/tests/test_get_slice_buffer.c
+++ b/tests/test_get_slice_buffer.c
@@ -80,7 +80,7 @@ static void test_get_slice(caterva_context_t *ctx, int8_t ndim, int8_t itemsize,
     for (int i = 0; i < ndim; ++i) {
         buffersize *= shape[i];
     }
-    double *buffer = malloc(buffersize);
+    double *buffer = ctx->cfg->alloc(buffersize);
     // fill_buf(buffer, itemsize, buffersize / itemsize);
     for (int i = 0; i < (buffersize/itemsize); ++i) {
         buffer[i] = (double) i;
@@ -95,7 +95,7 @@ static void test_get_slice(caterva_context_t *ctx, int8_t ndim, int8_t itemsize,
     for (int i = 0; i < ndim; ++i) {
         destbuffersize *= destshape[i];
     }
-    uint8_t *destbuffer = malloc(destbuffersize);
+    uint8_t *destbuffer = ctx->cfg->alloc(destbuffersize);
 
     /* Fill dest buffer with a slice*/
     CATERVA_TEST_ERROR(caterva_array_get_slice_buffer(ctx, src, start, stop, destshape, destbuffer, destbuffersize));
@@ -103,8 +103,8 @@ static void test_get_slice(caterva_context_t *ctx, int8_t ndim, int8_t itemsize,
     /* Assert results */
     assert_buf(destbuffer, result, itemsize, destbuffersize/itemsize, 1e-14);
 
-    free(buffer);
-    free(destbuffer);
+    ctx->cfg->free(buffer);
+    ctx->cfg->free(destbuffer);
     CATERVA_TEST_ERROR(caterva_array_free(ctx, &src));
 }
 

--- a/tests/test_get_slice_buffer.c
+++ b/tests/test_get_slice_buffer.c
@@ -148,7 +148,7 @@ LWTEST_FIXTURE(get_slice_buffer, 1_double_blosc) {
     test_get_slice(data->ctx, ndim, itemsize, shape, backend, chunkshape, blockshape, enforceframe, filename,
                    start, stop, destshape, result);
 }
-/*
+
 LWTEST_FIXTURE(get_slice_buffer, 2_double_blosc) {
 
     int64_t start[] = {5, 3};
@@ -162,8 +162,8 @@ LWTEST_FIXTURE(get_slice_buffer, 2_double_blosc) {
     int64_t shape[] = {10, 10};
 
     caterva_storage_backend_t backend = CATERVA_STORAGE_BLOSC;
-    int64_t chunkshape[] = {2, 3};
-    int64_t blockshaoe[] = {1, 2};
+    int64_t chunkshape[] = {4, 7};
+    int64_t blockshaoe[] = {3, 6};
     bool enforceframe = false;
     char *filename = NULL;
 
@@ -175,7 +175,7 @@ LWTEST_FIXTURE(get_slice_buffer, 2_double_blosc) {
         start, stop, destshape, result);
 }
 
-LWTEST_FIXTURE(get_slice_buffer, 2_pad) {
+LWTEST_FIXTURE(get_slice_buffer, 2_plainbuffer) {
 
     int64_t start[] = {2, 2};
     int64_t stop[] = {4, 4};
@@ -186,9 +186,9 @@ LWTEST_FIXTURE(get_slice_buffer, 2_pad) {
     uint8_t ndim = 2;
     int64_t shape[] = {5, 6};
 
-    caterva_storage_backend_t backend = CATERVA_STORAGE_BLOSC;
-    int64_t chunkshape[] = {3, 3};
-    int64_t blockshape[] = {2, 2};
+    caterva_storage_backend_t backend = CATERVA_STORAGE_PLAINBUFFER;
+    int64_t chunkshape[] = {0};
+    int64_t blockshape[] = {0};
     bool enforceframe = false;
     char *filename = NULL;
 
@@ -200,7 +200,7 @@ LWTEST_FIXTURE(get_slice_buffer, 2_pad) {
                    start, stop, destshape, result);
 }
 
-LWTEST_FIXTURE(get_slice_buffer, 3_float_blosc) {
+LWTEST_FIXTURE(get_slice_buffer, 3_float_plainbuffer) {
 
     int64_t start[] = {2, 2, 0};
     int64_t stop[] = {4, 4, 2};
@@ -211,9 +211,9 @@ LWTEST_FIXTURE(get_slice_buffer, 3_float_blosc) {
     uint8_t ndim = 3;
     int64_t shape[] = {5, 6, 3};
 
-    caterva_storage_backend_t backend = CATERVA_STORAGE_BLOSC;
-    int64_t chunkshape[] = {3, 3, 3};
-    int64_t blockshape[] = {2, 2, 2};
+    caterva_storage_backend_t backend = CATERVA_STORAGE_PLAINBUFFER;
+    int64_t chunkshape[] = {0};
+    int64_t blockshape[] = {0};
     bool enforceframe = false;
     char *filename = NULL;
 
@@ -225,10 +225,10 @@ LWTEST_FIXTURE(get_slice_buffer, 3_float_blosc) {
     test_get_slice(data->ctx, ndim, itemsize, shape, backend, chunkshape, blockshape, enforceframe, filename,
                    start, stop, destshape, result);
 }
-*/
 
-LWTEST_FIXTURE(get_slice_buffer, ndim_3_pad) {
-    uint8_t itemsize = sizeof(float);
+
+LWTEST_FIXTURE(get_slice_buffer, 3_float_blosc) {
+    uint8_t itemsize = sizeof(double);
     uint8_t ndim = 3;
     int64_t shape_[] = {10, 10, 10};
     int64_t pshape_[] = {3, 5, 2};
@@ -246,7 +246,7 @@ LWTEST_FIXTURE(get_slice_buffer, ndim_3_pad) {
     }
 
 
-    float result[1024] = {303, 304, 305, 306, 307, 308, 309, 313, 314, 315, 316, 317, 318, 319,
+    double result[1024] = {303, 304, 305, 306, 307, 308, 309, 313, 314, 315, 316, 317, 318, 319,
                            323, 324, 325, 326, 327, 328, 329, 333, 334, 335, 336, 337, 338, 339,
                            343, 344, 345, 346, 347, 348, 349, 353, 354, 355, 356, 357, 358, 359,
                            363, 364, 365, 366, 367, 368, 369, 403, 404, 405, 406, 407, 408, 409,

--- a/tests/test_get_slice_buffer.c
+++ b/tests/test_get_slice_buffer.c
@@ -125,6 +125,31 @@ LWTEST_TEARDOWN(get_slice_buffer) {
     caterva_context_free(&data->ctx);
 }
 
+LWTEST_FIXTURE(get_slice_buffer, 1_acceleration_path) {
+    int64_t start[] = {0};
+    int64_t stop[] = {30};
+
+    double result[1024] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16,
+                           17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29};
+
+    uint8_t itemsize = sizeof(double);
+    uint8_t ndim = 1;
+    int64_t shape[] = {30};
+
+    caterva_storage_backend_t backend = CATERVA_STORAGE_BLOSC;
+    int64_t chunkshape[] = {30};
+    int64_t blockshape[] = {30};
+    bool enforceframe = false;
+    char *filename = NULL;
+
+    int64_t destshape[] = {0};
+    for (int i = 0; i < ndim; ++i) {
+        destshape[i] = stop[i] - start[i];
+    }
+    test_get_slice(data->ctx, ndim, itemsize, shape, backend, chunkshape, blockshape, enforceframe, filename,
+                   start, stop, destshape, result);
+}
+
 LWTEST_FIXTURE(get_slice_buffer, 1_double_blosc) {
     int64_t start[] = {2};
     int64_t stop[] = {9};

--- a/tests/test_get_slice_buffer.c
+++ b/tests/test_get_slice_buffer.c
@@ -124,8 +124,8 @@ LWTEST_SETUP(get_slice_buffer) {
 LWTEST_TEARDOWN(get_slice_buffer) {
     caterva_context_free(&data->ctx);
 }
-/*
-LWTEST_FIXTURE(get_slice_buffer, 1_double_plainbuffer) {
+
+LWTEST_FIXTURE(get_slice_buffer, 1_double_blosc) {
     int64_t start[] = {2};
     int64_t stop[] = {9};
 
@@ -133,11 +133,11 @@ LWTEST_FIXTURE(get_slice_buffer, 1_double_plainbuffer) {
 
     uint8_t itemsize = sizeof(double);
     uint8_t ndim = 1;
-    int64_t shape[] = {10};
+    int64_t shape[] = {30};
 
-    caterva_storage_backend_t backend = CATERVA_STORAGE_PLAINBUFFER;
-    int64_t chunkshape[] = {0};
-    int64_t blockshape[] = {0};
+    caterva_storage_backend_t backend = CATERVA_STORAGE_BLOSC;
+    int64_t chunkshape[] = {30};
+    int64_t blockshape[] = {20};
     bool enforceframe = false;
     char *filename = NULL;
 
@@ -148,7 +148,7 @@ LWTEST_FIXTURE(get_slice_buffer, 1_double_plainbuffer) {
     test_get_slice(data->ctx, ndim, itemsize, shape, backend, chunkshape, blockshape, enforceframe, filename,
                    start, stop, destshape, result);
 }
-
+/*
 LWTEST_FIXTURE(get_slice_buffer, 2_double_blosc) {
 
     int64_t start[] = {5, 3};

--- a/tests/test_get_slice_buffer.c
+++ b/tests/test_get_slice_buffer.c
@@ -83,7 +83,11 @@ static void test_get_slice(caterva_context_t *ctx, int8_t ndim, int8_t itemsize,
     double *buffer = ctx->cfg->alloc(buffersize);
     // fill_buf(buffer, itemsize, buffersize / itemsize);
     for (int i = 0; i < (buffersize/itemsize); ++i) {
-        buffer[i] = (double) i;
+        if (itemsize == 4) {
+            ((float *) buffer)[i] = (float) i;
+        } else {
+            ((double *) buffer)[i] = (double) i;
+        }
     }
 
     /* Create caterva_array_t with original data */
@@ -224,7 +228,7 @@ LWTEST_FIXTURE(get_slice_buffer, 3_float_blosc) {
 */
 
 LWTEST_FIXTURE(get_slice_buffer, ndim_3_pad) {
-    uint8_t itemsize = sizeof(double);
+    uint8_t itemsize = sizeof(float);
     uint8_t ndim = 3;
     int64_t shape_[] = {10, 10, 10};
     int64_t pshape_[] = {3, 5, 2};
@@ -242,7 +246,7 @@ LWTEST_FIXTURE(get_slice_buffer, ndim_3_pad) {
     }
 
 
-    double result[1024] = {303, 304, 305, 306, 307, 308, 309, 313, 314, 315, 316, 317, 318, 319,
+    float result[1024] = {303, 304, 305, 306, 307, 308, 309, 313, 314, 315, 316, 317, 318, 319,
                            323, 324, 325, 326, 327, 328, 329, 333, 334, 335, 336, 337, 338, 339,
                            343, 344, 345, 346, 347, 348, 349, 353, 354, 355, 356, 357, 358, 359,
                            363, 364, 365, 366, 367, 368, 369, 403, 404, 405, 406, 407, 408, 409,
@@ -300,13 +304,13 @@ LWTEST_FIXTURE(get_slice_buffer, 4_float_blosc) {
     int64_t start[] = {5, 3, 9, 2};
     int64_t stop[] = {9, 6, 10, 7};
 
-    double result[1024] = {5392, 5393, 5394, 5395, 5396, 5492, 5493, 5494, 5495, 5496, 5592, 5593,
+    float result[1024] = {5392, 5393, 5394, 5395, 5396, 5492, 5493, 5494, 5495, 5496, 5592, 5593,
                           5594, 5595, 5596, 6392, 6393, 6394, 6395, 6396, 6492, 6493, 6494, 6495,
                           6496, 6592, 6593, 6594, 6595, 6596, 7392, 7393, 7394, 7395, 7396, 7492,
                           7493, 7494, 7495, 7496, 7592, 7593, 7594, 7595, 7596, 8392, 8393, 8394,
                           8395, 8396, 8492, 8493, 8494, 8495, 8496, 8592, 8593, 8594, 8595, 8596};
 
-    uint8_t itemsize = sizeof(double);
+    uint8_t itemsize = sizeof(float);
     uint8_t ndim = 4;
     int64_t shape[] = {10, 10, 10, 10};
 
@@ -392,7 +396,7 @@ LWTEST_FIXTURE(get_slice_buffer, 7_float_plainbuffer) {
     int64_t start[] = {5, 4, 3, 8, 4, 5, 1};
     int64_t stop[] = {8, 6, 5, 9, 7, 7, 3};
 
-    double result[1024] = {5438451, 5438452, 5438461, 5438462, 5438551, 5438552, 5438561, 5438562,
+    float result[1024] = {5438451, 5438452, 5438461, 5438462, 5438551, 5438552, 5438561, 5438562,
                           5438651, 5438652, 5438661, 5438662, 5448451, 5448452, 5448461, 5448462,
                           5448551, 5448552, 5448561, 5448562, 5448651, 5448652, 5448661, 5448662,
                           5538451, 5538452, 5538461, 5538462, 5538551, 5538552, 5538561, 5538562,
@@ -411,7 +415,7 @@ LWTEST_FIXTURE(get_slice_buffer, 7_float_plainbuffer) {
                           7538651, 7538652, 7538661, 7538662, 7548451, 7548452, 7548461, 7548462,
                           7548551, 7548552, 7548561, 7548562, 7548651, 7548652, 7548661, 7548662};
 
-    uint8_t itemsize = sizeof(double);
+    uint8_t itemsize = sizeof(float);
     uint8_t ndim = 7;
     int64_t shape[] = {10, 10, 10, 10, 10, 10, 10};
 

--- a/tests/test_get_slice_buffer.c
+++ b/tests/test_get_slice_buffer.c
@@ -105,6 +105,10 @@ static void test_get_slice(caterva_context_t *ctx, int8_t ndim, int8_t itemsize,
     /* Fill dest buffer with a slice*/
     CATERVA_TEST_ERROR(caterva_array_get_slice_buffer(ctx, src, start, stop, destshape, destbuffer, destbuffersize));
 
+    printf("\n slice: \n");
+    for (int i=0; i < destbuffersize/itemsize; i++) {
+        printf("%f, ", ((double *) destbuffer)[i]);
+    }
     /* Assert results */
     assert_buf(destbuffer, result, itemsize, destbuffersize/itemsize, 1e-14);
 
@@ -228,6 +232,47 @@ LWTEST_FIXTURE(get_slice_buffer, 3_float_blosc) {
 }
 */
 
+LWTEST_FIXTURE(get_slice_buffer, ndim_3_pad) {
+    uint8_t itemsize = sizeof(double);
+    uint8_t ndim = 3;
+    int64_t shape_[] = {10, 10, 10};
+    int64_t pshape_[] = {3, 5, 2};
+    int64_t spshape_[] = {3, 3, 2};
+    int64_t start[] = {3, 0, 3};
+    int64_t stop[] = {6, 7, 10};
+
+    caterva_storage_backend_t backend = CATERVA_STORAGE_BLOSC;
+    bool enforceframe = false;
+    char *filename = NULL;
+
+    int64_t destshape[] = {0, 0, 0};
+    for (int i = 0; i < ndim; ++i) {
+        destshape[i] = stop[i] - start[i];
+    }
+
+
+    double result[1024] = {303, 304, 305, 306, 307, 308, 309, 313, 314, 315, 316, 317, 318, 319,
+                           323, 324, 325, 326, 327, 328, 329, 333, 334, 335, 336, 337, 338, 339,
+                           343, 344, 345, 346, 347, 348, 349, 353, 354, 355, 356, 357, 358, 359,
+                           363, 364, 365, 366, 367, 368, 369, 403, 404, 405, 406, 407, 408, 409,
+                           413, 414, 415, 416, 417, 418, 419, 423, 424, 425, 426, 427, 428, 429,
+                           433, 434, 435, 436, 437, 438, 439, 443, 444, 445, 446, 447, 448, 449,
+                           453, 454, 455, 456, 457, 458, 459, 463, 464, 465, 466, 467, 468, 469,
+                           503, 504, 505, 506, 507, 508, 509, 513, 514, 515, 516, 517, 518, 519,
+                           523, 524, 525, 526, 527, 528, 529, 533, 534, 535, 536, 537, 538, 539,
+                           543, 544, 545, 546, 547, 548, 549, 553, 554, 555, 556, 557, 558, 559,
+                           563, 564, 565, 566, 567, 568, 569};
+
+    printf("\n result: \n");
+    for (int i=0; i < 10; i++) {
+        printf("%f, ", (double) result[i]);
+    }
+
+    test_get_slice(data->ctx, ndim, itemsize, shape_, backend, pshape_, spshape_, enforceframe, filename,
+                   start, stop, destshape, result);
+}
+
+
 LWTEST_FIXTURE(get_slice_buffer, ndim_3_no_sp) {
     uint8_t itemsize = sizeof(double);
     uint8_t ndim = 3;
@@ -268,25 +313,25 @@ LWTEST_FIXTURE(get_slice_buffer, ndim_3_no_sp) {
                    start, stop, destshape, result);
 }
 
-/*
-LWTEST_FIXTURE(get_slice_buffer, 4_float_blosc_frame) {
+
+LWTEST_FIXTURE(get_slice_buffer, 4_float_blosc) {
 
     int64_t start[] = {5, 3, 9, 2};
     int64_t stop[] = {9, 6, 10, 7};
 
-    float result[1024] = {5392, 5393, 5394, 5395, 5396, 5492, 5493, 5494, 5495, 5496, 5592, 5593,
+    double result[1024] = {5392, 5393, 5394, 5395, 5396, 5492, 5493, 5494, 5495, 5496, 5592, 5593,
                           5594, 5595, 5596, 6392, 6393, 6394, 6395, 6396, 6492, 6493, 6494, 6495,
                           6496, 6592, 6593, 6594, 6595, 6596, 7392, 7393, 7394, 7395, 7396, 7492,
                           7493, 7494, 7495, 7496, 7592, 7593, 7594, 7595, 7596, 8392, 8393, 8394,
                           8395, 8396, 8492, 8493, 8494, 8495, 8496, 8592, 8593, 8594, 8595, 8596};
 
-    uint8_t itemsize = sizeof(float);
+    uint8_t itemsize = sizeof(double);
     uint8_t ndim = 4;
     int64_t shape[] = {10, 10, 10, 10};
 
     caterva_storage_backend_t backend = CATERVA_STORAGE_BLOSC;
     int64_t chunkshape[] = {3, 2, 3, 2};
-    int64_t blockshape[] = {3, 2, 3, 2};
+    int64_t blockshape[] = {3, 2, 2, 2};
     bool enforceframe = true;
     char *filename = NULL;
 
@@ -349,7 +394,7 @@ LWTEST_FIXTURE(get_slice_buffer, 6_double_blosc) {
 
     caterva_storage_backend_t backend = CATERVA_STORAGE_BLOSC;
     int64_t chunkshape[] = {6, 5, 3, 5, 4, 2};
-    int64_t blockshape[] = {1, 1, 1, 1, 1, 1};
+    int64_t blockshape[] = {3, 2, 3, 5, 4, 2};
     bool enforceframe = false;
     char *filename = NULL;
 
@@ -366,7 +411,7 @@ LWTEST_FIXTURE(get_slice_buffer, 7_float_plainbuffer) {
     int64_t start[] = {5, 4, 3, 8, 4, 5, 1};
     int64_t stop[] = {8, 6, 5, 9, 7, 7, 3};
 
-    float result[1024] = {5438451, 5438452, 5438461, 5438462, 5438551, 5438552, 5438561, 5438562,
+    double result[1024] = {5438451, 5438452, 5438461, 5438462, 5438551, 5438552, 5438561, 5438562,
                           5438651, 5438652, 5438661, 5438662, 5448451, 5448452, 5448461, 5448462,
                           5448551, 5448552, 5448561, 5448562, 5448651, 5448652, 5448661, 5448662,
                           5538451, 5538452, 5538461, 5538462, 5538551, 5538552, 5538561, 5538562,
@@ -385,7 +430,7 @@ LWTEST_FIXTURE(get_slice_buffer, 7_float_plainbuffer) {
                           7538651, 7538652, 7538661, 7538662, 7548451, 7548452, 7548461, 7548462,
                           7548551, 7548552, 7548561, 7548562, 7548651, 7548652, 7548661, 7548662};
 
-    uint8_t itemsize = sizeof(float);
+    uint8_t itemsize = sizeof(double);
     uint8_t ndim = 7;
     int64_t shape[] = {10, 10, 10, 10, 10, 10, 10};
 
@@ -408,16 +453,16 @@ LWTEST_FIXTURE(get_slice_buffer, 8_float_blosc) {
     int64_t start[] = {3, 2, 2, 2, 2, 1, 1, 1};
     int64_t stop[] = {4, 3, 3, 3, 3, 3, 2, 3};
 
-    float result[1024] = {16750, 16751, 16756, 16757};
+    double result[1024] = {16750, 16751, 16756, 16757};
 
-    uint8_t itemsize = sizeof(float);
+    uint8_t itemsize = sizeof(double);
     uint8_t ndim = 8;
     int64_t shape[] = {5, 3, 4, 5, 4, 3, 2, 3};
 
     caterva_storage_backend_t backend = CATERVA_STORAGE_BLOSC;
     int64_t chunkshape[] = {2, 2, 1, 1, 2, 2, 1, 1};
-    int64_t blockshape[] = {1, 1, 1, 1, 1, 1, 1, 1};
-    bool enforceframe = true;
+    int64_t blockshape[] = {2, 2, 1, 1, 2, 2, 1, 1};
+    bool enforceframe = false;
     char *filename = NULL;
 
     int64_t destshape[] = {0, 0, 0, 0, 0, 0, 0, 0};
@@ -428,4 +473,3 @@ LWTEST_FIXTURE(get_slice_buffer, 8_float_blosc) {
     test_get_slice(data->ctx, ndim, itemsize, shape, backend, chunkshape, blockshape, enforceframe, filename,
                    start, stop, destshape, result);
 }
-*/

--- a/tests/test_get_slice_buffer.c
+++ b/tests/test_get_slice_buffer.c
@@ -86,11 +86,6 @@ static void test_get_slice(caterva_context_t *ctx, int8_t ndim, int8_t itemsize,
         buffer[i] = (double) i;
     }
 
-    printf("\n buffer: \n");
-    for (int i=0; i < 700; i++) {
-        printf("%f, ", buffer[i]);
-    }
-
     /* Create caterva_array_t with original data */
     caterva_array_t *src;
     CATERVA_TEST_ERROR(caterva_array_from_buffer(ctx, buffer, buffersize, &params, &storage, &src));
@@ -105,10 +100,6 @@ static void test_get_slice(caterva_context_t *ctx, int8_t ndim, int8_t itemsize,
     /* Fill dest buffer with a slice*/
     CATERVA_TEST_ERROR(caterva_array_get_slice_buffer(ctx, src, start, stop, destshape, destbuffer, destbuffersize));
 
-    printf("\n slice: \n");
-    for (int i=0; i < destbuffersize/itemsize; i++) {
-        printf("%f, ", ((double *) destbuffer)[i]);
-    }
     /* Assert results */
     assert_buf(destbuffer, result, itemsize, destbuffersize/itemsize, 1e-14);
 

--- a/tests/test_get_slice_buffer.c
+++ b/tests/test_get_slice_buffer.c
@@ -58,7 +58,7 @@ static void test_get_slice(caterva_context_t *ctx, int8_t ndim, int8_t itemsize,
         params.shape[i] = shape[i];
     }
 
-    caterva_storage_t storage;
+    caterva_storage_t storage = {0};
     storage.backend = backend;
     switch (backend) {
         case CATERVA_STORAGE_PLAINBUFFER:
@@ -254,11 +254,6 @@ LWTEST_FIXTURE(get_slice_buffer, ndim_3_pad) {
                            543, 544, 545, 546, 547, 548, 549, 553, 554, 555, 556, 557, 558, 559,
                            563, 564, 565, 566, 567, 568, 569};
 
-    printf("\n result: \n");
-    for (int i=0; i < 10; i++) {
-        printf("%f, ", (double) result[i]);
-    }
-
     test_get_slice(data->ctx, ndim, itemsize, shape_, backend, pshape_, spshape_, enforceframe, filename,
                    start, stop, destshape, result);
 }
@@ -294,11 +289,6 @@ LWTEST_FIXTURE(get_slice_buffer, ndim_3_no_sp) {
                            523, 524, 525, 526, 527, 528, 529, 533, 534, 535, 536, 537, 538, 539,
                            543, 544, 545, 546, 547, 548, 549, 553, 554, 555, 556, 557, 558, 559,
                            563, 564, 565, 566, 567, 568, 569};
-
-    printf("\n result: \n");
-    for (int i=0; i < 10; i++) {
-        printf("%f, ", (double) result[i]);
-    }
 
     test_get_slice(data->ctx, ndim, itemsize, shape_, backend, pshape_, spshape_, enforceframe, filename,
                    start, stop, destshape, result);

--- a/tests/test_get_slice_buffer.c
+++ b/tests/test_get_slice_buffer.c
@@ -83,10 +83,21 @@ static void test_get_slice(caterva_context_t *ctx, int8_t ndim, int8_t itemsize,
     double *buffer = ctx->cfg->alloc(buffersize);
     // fill_buf(buffer, itemsize, buffersize / itemsize);
     for (int i = 0; i < (buffersize/itemsize); ++i) {
-        if (itemsize == 4) {
-            ((float *) buffer)[i] = (float) i;
-        } else {
-            ((double *) buffer)[i] = (double) i;
+        switch (itemsize) {
+            case 1:
+                ((uint8_t *) buffer)[i] = (uint8_t) i;
+                break;
+            case 2:
+                ((uint16_t *) buffer)[i] = (uint16_t) i;
+                break;
+            case 4:
+                ((float *) buffer)[i] = (float) i;
+                break;
+            case 8:
+                ((double *) buffer)[i] = (double) i;
+                break;
+            default:
+                CATERVA_TEST_ERROR(CATERVA_ERR_INVALID_STORAGE);
         }
     }
 
@@ -174,21 +185,21 @@ LWTEST_FIXTURE(get_slice_buffer, 1_double_blosc) {
                    start, stop, destshape, result);
 }
 
-LWTEST_FIXTURE(get_slice_buffer, 2_double_blosc) {
+LWTEST_FIXTURE(get_slice_buffer, 2_uint16_blosc) {
 
     int64_t start[] = {5, 3};
     int64_t stop[] = {9, 10};
 
-    double result[1024] = {53, 54, 55, 56, 57, 58, 59, 63, 64, 65, 66, 67, 68, 69, 73, 74, 75, 76,
+    uint16_t result[1024] = {53, 54, 55, 56, 57, 58, 59, 63, 64, 65, 66, 67, 68, 69, 73, 74, 75, 76,
                            77, 78, 79, 83, 84, 85, 86, 87, 88, 89};
 
-    uint8_t itemsize = sizeof(double);
+    uint8_t itemsize = sizeof(uint16_t);
     uint8_t ndim = 2;
-    int64_t shape[] = {10, 10};
+    int64_t shape[] = {14, 10};
 
     caterva_storage_backend_t backend = CATERVA_STORAGE_BLOSC;
-    int64_t chunkshape[] = {4, 7};
-    int64_t blockshaoe[] = {3, 6};
+    int64_t chunkshape[] = {11, 9};
+    int64_t blockshaoe[] = {9, 8};
     bool enforceframe = false;
     char *filename = NULL;
 
@@ -200,14 +211,14 @@ LWTEST_FIXTURE(get_slice_buffer, 2_double_blosc) {
         start, stop, destshape, result);
 }
 
-LWTEST_FIXTURE(get_slice_buffer, 2_plainbuffer) {
+LWTEST_FIXTURE(get_slice_buffer, 2_uint8_plainbuffer) {
 
     int64_t start[] = {2, 2};
     int64_t stop[] = {4, 4};
 
-    double result[1024] = {14, 15, 20, 21};
+    uint8_t result[1024] = {14, 15, 20, 21};
 
-    uint8_t itemsize = sizeof(double);
+    uint8_t itemsize = sizeof(uint8_t);
     uint8_t ndim = 2;
     int64_t shape[] = {5, 6};
 

--- a/tests/test_get_slice_buffer.c
+++ b/tests/test_get_slice_buffer.c
@@ -80,15 +80,15 @@ static void test_get_slice(caterva_context_t *ctx, int8_t ndim, int8_t itemsize,
     for (int i = 0; i < ndim; ++i) {
         buffersize *= shape[i];
     }
-    uint8_t *buffer = malloc(buffersize);
+    double *buffer = malloc(buffersize);
     // fill_buf(buffer, itemsize, buffersize / itemsize);
     for (int i = 0; i < (buffersize/itemsize); ++i) {
         buffer[i] = (double) i;
     }
 
     printf("\n buffer: \n");
-    for (int i=0; i < 25; i++) {
-        printf("%hhu, ", buffer[i]);
+    for (int i=0; i < 700; i++) {
+        printf("%f, ", buffer[i]);
     }
 
     /* Create caterva_array_t with original data */
@@ -229,7 +229,7 @@ LWTEST_FIXTURE(get_slice_buffer, 3_float_blosc) {
 */
 
 LWTEST_FIXTURE(get_slice_buffer, ndim_3_no_sp) {
-    uint8_t itemsize = sizeof(float);
+    uint8_t itemsize = sizeof(double);
     uint8_t ndim = 3;
     int64_t shape_[] = {10, 10, 10};
     int64_t pshape_[] = {3, 5, 2};
@@ -259,11 +259,16 @@ LWTEST_FIXTURE(get_slice_buffer, ndim_3_no_sp) {
                            543, 544, 545, 546, 547, 548, 549, 553, 554, 555, 556, 557, 558, 559,
                            563, 564, 565, 566, 567, 568, 569};
 
+    printf("\n result: \n");
+    for (int i=0; i < 10; i++) {
+        printf("%f, ", (double) result[i]);
+    }
 
     test_get_slice(data->ctx, ndim, itemsize, shape_, backend, pshape_, spshape_, enforceframe, filename,
-                   start, stop, destshape, result);}
+                   start, stop, destshape, result);
+}
 
-
+/*
 LWTEST_FIXTURE(get_slice_buffer, 4_float_blosc_frame) {
 
     int64_t start[] = {5, 3, 9, 2};
@@ -324,7 +329,7 @@ LWTEST_FIXTURE(get_slice_buffer, 5_double_plainbuffer) {
                    start, stop, destshape, result);
 }
 
-/*
+
 LWTEST_FIXTURE(get_slice_buffer, 6_double_blosc) {
     int64_t start[] = {0, 4, 2, 4, 5, 1};
     int64_t stop[] = {1, 7, 4, 6, 8, 3};

--- a/tests/test_persistency.c
+++ b/tests/test_persistency.c
@@ -1,0 +1,224 @@
+/*
+ * Copyright (c) 2018 Francesc Alted, Aleix Alcacer.
+ * Copyright (C) 2019-present Blosc Development team <blosc@blosc.org>
+ * All rights reserved.
+ *
+ * This source code is licensed under both the BSD-style license (found in the
+ * LICENSE file in the root directory of this source tree) and the GPLv2 (found
+ * in the COPYING file in the root directory of this source tree).
+ * You may select, at your option, one of the above-listed licenses.
+ */
+
+#include "test_common.h"
+#include <unistd.h>
+
+static void test_persistency(caterva_context_t *ctx, uint8_t itemsize, uint8_t ndim, int64_t *shape,
+                             caterva_storage_backend_t backend, int64_t *chunkshape, int64_t *blockshape,
+                             bool enforceframe, char *filename) {
+
+    if (access(filename, F_OK) != -1) {
+        remove(filename);
+    }
+    caterva_params_t params;
+    params.itemsize = itemsize;
+    params.ndim = ndim;
+    for (int i = 0; i < ndim; ++i) {
+        params.shape[i] = shape[i];
+    }
+
+    caterva_storage_t storage = {0};
+    storage.backend = backend;
+    switch (backend) {
+        case CATERVA_STORAGE_PLAINBUFFER:
+            break;
+        case CATERVA_STORAGE_BLOSC:
+            storage.properties.blosc.filename = filename;
+            storage.properties.blosc.enforceframe = enforceframe;
+            for (int i = 0; i < ndim; ++i) {
+                storage.properties.blosc.chunkshape[i] = chunkshape[i];
+                storage.properties.blosc.blockshape[i] = blockshape[i];
+            }
+            break;
+        default:
+            CATERVA_TEST_ERROR(CATERVA_ERR_INVALID_STORAGE);
+    }
+
+    /* Create original data */
+    int64_t buffersize = itemsize;
+    for (int i = 0; i < ndim; ++i) {
+        buffersize *= shape[i];
+    }
+    uint8_t *buffer = malloc(buffersize);
+    fill_buf(buffer, itemsize, buffersize / itemsize);
+
+    /* Create caterva_array_t with original data */
+    caterva_array_t *src;
+    CATERVA_TEST_ERROR(caterva_array_from_buffer(ctx, buffer, buffersize, &params, &storage, &src));
+
+    caterva_array_t *dest;
+    caterva_array_from_file(ctx, filename, true, &dest);
+
+    /* Fill dest array with caterva_array_t data */
+    uint8_t *buffer_dest = malloc(buffersize);
+    CATERVA_TEST_ERROR(caterva_array_to_buffer(ctx, dest, buffer_dest, buffersize));
+
+    /* Testing */
+    double tol = (itemsize == 4) ? 1e-6 : 1e-15;
+    assert_buf(buffer, buffer_dest, itemsize, dest->size, tol);
+
+    /* Free mallocs */
+    free(buffer);
+    free(buffer_dest);
+    CATERVA_TEST_ERROR(caterva_array_free(ctx, &src));
+    CATERVA_TEST_ERROR(caterva_array_free(ctx, &dest));
+    if (access(filename, F_OK) != -1) {
+        remove(filename);
+    }
+}
+
+
+LWTEST_DATA(persistency) {
+    caterva_context_t *ctx;
+    char *filename;
+};
+
+LWTEST_SETUP(persistency) {
+    caterva_config_t cfg = CATERVA_CONFIG_DEFAULTS;
+    caterva_context_new(&cfg, &data->ctx);
+    data->filename = "persistency.caterva";
+}
+
+LWTEST_TEARDOWN(persistency) {
+    caterva_context_free(&data->ctx);
+}
+
+
+LWTEST_FIXTURE(persistency, 1_uint16) {
+    uint8_t itemsize = sizeof(uint16_t);
+    uint8_t ndim = 1;
+    int64_t shape[] = {500};
+
+    caterva_storage_backend_t backend = CATERVA_STORAGE_BLOSC;
+    int64_t chunkshape[] = {200};
+    int64_t blockshape[] = {80};
+    bool enforceframe = true;
+    char *filename = data->filename;
+
+    test_persistency(data->ctx, itemsize, ndim, shape, backend, chunkshape, blockshape, enforceframe, filename);
+}
+
+LWTEST_FIXTURE(persistency, 2_uint8) {
+    uint8_t itemsize = sizeof(uint8_t);
+    uint8_t ndim = 2;
+    int64_t shape[] = {400, 300};
+
+    caterva_storage_backend_t backend = CATERVA_STORAGE_BLOSC;
+    int64_t chunkshape[] = {55, 67};
+    int64_t blockshape[] = {40, 40};
+    bool enforceframe = true;
+    char *filename = data->filename;
+
+    test_persistency(data->ctx, itemsize, ndim, shape, backend, chunkshape, blockshape, enforceframe, filename);
+}
+
+
+LWTEST_FIXTURE(persistency, 3_double) {
+    uint8_t itemsize = sizeof(double);
+    uint8_t ndim = 3;
+    int64_t shape[] = {134, 56, 204};
+
+    caterva_storage_backend_t backend = CATERVA_STORAGE_BLOSC;
+    int64_t chunkshape[] = {26, 17, 34};
+    int64_t blockshape[] = {11, 8, 13};
+    bool enforceframe = true;
+    char *filename = data->filename;
+
+    test_persistency(data->ctx, itemsize, ndim, shape, backend, chunkshape, blockshape, enforceframe, filename);
+
+}
+
+
+LWTEST_FIXTURE(persistency, 4_float) {
+    uint8_t itemsize = sizeof(float);
+    uint8_t ndim = 4;
+    int64_t shape[] = {10, 13, 18, 25};
+
+    caterva_storage_backend_t backend = CATERVA_STORAGE_BLOSC;
+    int64_t chunkshape[] = {9, 5, 11, 10};
+    int64_t blockshape[] = {2, 2, 5, 3};
+    bool enforceframe = true;
+    char *filename = data->filename;
+
+    test_persistency(data->ctx, itemsize, ndim, shape, backend, chunkshape, blockshape, enforceframe, filename);
+}
+
+LWTEST_FIXTURE(persistency, 4_uint8) {
+    uint8_t itemsize = sizeof(uint8_t);
+    uint8_t ndim = 4;
+    int64_t shape[] = {78, 85, 34, 56};
+
+    caterva_storage_backend_t backend = CATERVA_STORAGE_BLOSC;
+    int64_t chunkshape[] = {23, 12, 24, 50};
+    int64_t blockshape[] = {11, 5, 7, 13};
+    bool enforceframe = true;
+    char *filename = data->filename;
+
+    test_persistency(data->ctx, itemsize, ndim, shape, backend, chunkshape, blockshape, enforceframe, filename);
+}
+
+
+LWTEST_FIXTURE(persistency, 5_double) {
+    uint8_t itemsize = sizeof(double);
+    uint8_t ndim = 5;
+    int64_t shape[] = {25, 27, 24, 25, 12};
+
+    caterva_storage_backend_t backend = CATERVA_STORAGE_BLOSC;
+    int64_t chunkshape[] = {10, 15, 8, 11, 11};
+    int64_t blockshape[] = {3, 3, 3, 3, 3};
+    bool enforceframe = true;
+    char *filename = data->filename;
+
+    test_persistency(data->ctx, itemsize, ndim, shape, backend, chunkshape, blockshape, enforceframe, filename);
+}
+
+LWTEST_FIXTURE(persistency, 6_uint16) {
+    uint8_t itemsize = sizeof(uint16_t);
+    uint8_t ndim = 6;
+    int64_t shape[] = {4, 3, 8, 5, 10, 12};
+
+    caterva_storage_backend_t backend = CATERVA_STORAGE_BLOSC;
+    int64_t chunkshape[] = {2, 2, 3, 3, 4, 5};
+    int64_t blockshape[] = {2, 1, 2, 2, 3, 4};
+    bool enforceframe = true;
+    char *filename = data->filename;
+
+    test_persistency(data->ctx, itemsize, ndim, shape, backend, chunkshape, blockshape, enforceframe, filename);
+}
+
+LWTEST_FIXTURE(persistency, 7_uint64) {
+    uint8_t itemsize = sizeof(uint64_t);
+    uint8_t ndim = 7;
+    int64_t shape[] =  {4, 15, 11, 6, 12, 8, 7};
+
+    caterva_storage_backend_t backend = CATERVA_STORAGE_BLOSC;
+    int64_t chunkshape[] = {4, 3, 4, 3, 3, 5, 3};
+    int64_t blockshape[] = {1, 3, 2, 2, 1, 2, 2};
+    bool enforceframe = true;
+    char *filename = data->filename;
+
+    test_persistency(data->ctx, itemsize, ndim, shape, backend, chunkshape, blockshape, enforceframe, filename);
+}
+
+LWTEST_FIXTURE(persistency, 8_uint8) {
+    uint8_t itemsize = sizeof(uint8_t);
+    uint8_t ndim = 8;
+    int64_t shape[] = {4, 3, 8, 5, 10, 12, 6, 4};
+
+    caterva_storage_backend_t backend = CATERVA_STORAGE_BLOSC;
+    int64_t chunkshape[] = {3, 2, 3, 3, 4, 5, 4, 2};
+    int64_t blockshape[] = {2, 1, 2, 2, 3, 4, 3, 1};
+    bool enforceframe = true;
+    char *filename = data->filename;
+
+    test_persistency(data->ctx, itemsize, ndim, shape, backend, chunkshape, blockshape, enforceframe, filename);
+}

--- a/tests/test_persistency.c
+++ b/tests/test_persistency.c
@@ -10,13 +10,19 @@
  */
 
 #include "test_common.h"
+#ifdef __GNUC__
 #include <unistd.h>
+#define FILE_EXISTS(filename) access(filename, F_OK)
+#else
+#include <io.h>
+#define FILE_EXISTS(filename) _access(filename, 0)
+#endif
 
 static void test_persistency(caterva_context_t *ctx, uint8_t itemsize, uint8_t ndim, int64_t *shape,
                              caterva_storage_backend_t backend, int64_t *chunkshape, int64_t *blockshape,
                              bool enforceframe, char *filename) {
 
-    if (access(filename, F_OK) != -1) {
+    if (FILE_EXISTS(filename) != -1) {
         remove(filename);
     }
     caterva_params_t params;
@@ -71,7 +77,7 @@ static void test_persistency(caterva_context_t *ctx, uint8_t itemsize, uint8_t n
     free(buffer_dest);
     CATERVA_TEST_ERROR(caterva_array_free(ctx, &src));
     CATERVA_TEST_ERROR(caterva_array_free(ctx, &dest));
-    if (access(filename, F_OK) != -1) {
+    if (FILE_EXISTS(filename) != -1) {
         remove(filename);
     }
 }

--- a/tests/test_repart_chunk.c
+++ b/tests/test_repart_chunk.c
@@ -22,7 +22,7 @@ static void test_repart_chunk(caterva_context_t *ctx, uint8_t itemsize, caterva_
     for (int i = 0; i < ndim; ++i) {
         params.shape[i] = shape_[i];
     }
-    caterva_storage_t storage;
+    caterva_storage_t storage = {0};
     storage.properties.blosc.filename = filename;
     storage.properties.blosc.enforceframe = enforceframe;
     storage.backend = backend;

--- a/tests/test_repart_chunk.c
+++ b/tests/test_repart_chunk.c
@@ -14,7 +14,7 @@
 
 static void test_repart_chunk(caterva_context_t *ctx, uint8_t itemsize, caterva_storage_backend_t backend, uint8_t ndim,
                               int64_t *shape_, int64_t *chunkshape, int64_t *blockshape, bool enforceframe,
-                              char *filename, double result[]) {
+                              char *filename, void *result) {
 
 
     caterva_params_t params;
@@ -44,18 +44,36 @@ static void test_repart_chunk(caterva_context_t *ctx, uint8_t itemsize, caterva_
 
     /* Fill empty caterva_array_t with blocks */
     int size_src = carr->chunksize * itemsize;
-    int size_dest = carr->extchunksize * itemsize;
-    double *buffer_src = (double *) ctx->cfg->alloc(size_src);
-    double *buffer_dest = (double *) ctx->cfg->alloc(size_dest);
+    int size_dest = (int) carr->extchunksize * itemsize;
+
+    uint8_t *buffer_src = ctx->cfg->alloc(size_src);
+    uint8_t *buffer_dest = ctx->cfg->alloc(size_dest);
+    memset(buffer_src, 0, size_src);
+    memset(buffer_dest, 0, size_dest);
     for (int i = 0; i < carr->chunksize; ++i) {
-        buffer_src[i] =  (double) i;
+        switch (itemsize) {
+            case 1:
+                ((uint8_t *) buffer_src)[i] = (uint8_t) i;
+                break;
+            case 2:
+                ((uint16_t *) buffer_src)[i] = (uint16_t) i;
+                break;
+            case 4:
+                ((float *) buffer_src)[i] = (float) i;
+                break;
+            case 8:
+                ((double *) buffer_src)[i] =  (double) i;
+                break;
+            default:
+                CATERVA_TEST_ERROR(CATERVA_ERR_INVALID_STORAGE);
+        }
     }
     int res = caterva_blosc_array_repart_chunk((int8_t *) buffer_dest, size_dest, buffer_src, size_src, carr);
     if (res != 0) {
         printf("Error code : %d\n", res);
     }
 
-    assert_buf((uint8_t*) buffer_dest, (uint8_t*) result, itemsize, (size_t)carr->extchunksize, 1e-8);   // tam epsize*typesize????????????????
+    assert_buf((const uint8_t *) buffer_dest, (const uint8_t*) result, itemsize, (size_t)carr->extchunksize, 1e-14);   // tam epsize*typesize????????????????
     ctx->cfg->free(buffer_src);
     ctx->cfg->free(buffer_dest);
     CATERVA_TEST_ERROR(caterva_array_free(ctx, &carr));
@@ -90,16 +108,16 @@ LWTEST_FIXTURE(repart_chunk, 2_dim) {
     test_repart_chunk(data->ctx, itemsize, backend, ndim, shape_, pshape_, spshape_, enforceframe, filename, result);
 }
 
-LWTEST_FIXTURE(repart_chunk, 2_dim_pad) {
+LWTEST_FIXTURE(repart_chunk, 2_dim_float) {
     const uint8_t ndim = 2;
-    uint8_t itemsize = sizeof(double);
+    uint8_t itemsize = sizeof(float);
     caterva_storage_backend_t backend = CATERVA_STORAGE_BLOSC;
     bool enforceframe = true;
     char *filename = NULL;
     int64_t shape__[] = {8, 16};
     int64_t pshape__[] = {4, 8};
     int64_t spshape__[] = {2, 3};
-    double result[1024] = {0, 1, 2, 8, 9, 10, 3, 4, 5, 11, 12, 13, 6, 7, 0, 14, 15, 0,
+    float result[1024] = {0, 1, 2, 8, 9, 10, 3, 4, 5, 11, 12, 13, 6, 7, 0, 14, 15, 0,
                            16, 17, 18, 24, 25, 26, 19, 20, 21, 27, 28, 29, 22, 23, 0, 30, 31, 0};
     test_repart_chunk(data->ctx, itemsize, backend, ndim, shape__, pshape__, spshape__, enforceframe, filename, result);
 }
@@ -118,29 +136,29 @@ LWTEST_FIXTURE(repart_chunk, 3_dim) {
     test_repart_chunk(data->ctx, itemsize, backend, ndim, shape_, pshape_, spshape_, enforceframe, filename, result);
 }
 
-LWTEST_FIXTURE(repart_chunk, 3_dim_pad) {
+LWTEST_FIXTURE(repart_chunk, 3_dim_uint16) {
     const uint8_t ndim = 3;
-    uint8_t itemsize = sizeof(double);
+    uint8_t itemsize = sizeof(uint16_t);
     caterva_storage_backend_t backend = CATERVA_STORAGE_BLOSC;
     bool enforceframe = true;
     char *filename = NULL;
     int64_t shape_[] = {4, 3, 2};
     int64_t pshape_[] = {2, 3, 2};
     int64_t spshape_[] = {1, 2, 1};
-    double result[1024] = {0, 2, 1, 3, 4, 0, 5, 0, 6, 8, 7, 9, 10, 0, 11, 0};
+    uint16_t result[1024] = {0, 2, 1, 3, 4, 0, 5, 0, 6, 8, 7, 9, 10, 0, 11, 0};
     test_repart_chunk(data->ctx, itemsize, backend, ndim, shape_, pshape_, spshape_, enforceframe, filename, result);
 }
 
-LWTEST_FIXTURE(repart_chunk, 3_dim_2) {
+LWTEST_FIXTURE(repart_chunk, 3_dim_uint8) {
     const uint8_t ndim = 3;
-    uint8_t itemsize = sizeof(double);
+    uint8_t itemsize = sizeof(uint8_t);
     caterva_storage_backend_t backend = CATERVA_STORAGE_BLOSC;
     bool enforceframe = true;
     char *filename = NULL;
     int64_t shape_[] = {5, 6, 3};
     int64_t pshape_[] = {4, 3, 3};
     int64_t spshape_[] = {3, 3, 2};
-    double result[1024] = {0.000000, 1.000000, 3.000000, 4.000000, 6.000000, 7.000000, 9.000000, 10.000000, 12.000000,
+    uint8_t result[1024] = {0.000000, 1.000000, 3.000000, 4.000000, 6.000000, 7.000000, 9.000000, 10.000000, 12.000000,
                            13.000000, 15.000000, 16.000000, 18.000000, 19.000000, 21.000000, 22.000000, 24.000000, 25.000000,
                            2.000000, 0.000000, 5.000000, 0.000000, 8.000000, 0.000000, 11.000000, 0.000000, 14.000000,
                            0.000000, 17.000000, 0.000000, 20.000000, 0.000000, 23.000000, 0.000000, 26.000000, 0.000000,
@@ -161,16 +179,16 @@ LWTEST_FIXTURE(repart_chunk, 4_dim) {
     test_repart_chunk(data->ctx, itemsize, backend, ndim, shape_, pshape_, spshape_, enforceframe, filename, result);
 }
 
-LWTEST_FIXTURE(repart_chunk, 4_dim_pad) {
+LWTEST_FIXTURE(repart_chunk, 4_dim_float) {
     const uint8_t ndim = 4;
-    uint8_t itemsize = sizeof(double);
+    uint8_t itemsize = sizeof(float);
     caterva_storage_backend_t backend = CATERVA_STORAGE_BLOSC;
     bool enforceframe = true;
     char *filename = NULL;
     int64_t shape_[] = {4, 3, 2, 6};
     int64_t pshape_[] = {2, 3, 2, 2};
     int64_t spshape_[] = {1, 2, 1, 1};
-    double result[1024] = {0, 4, 1, 5, 2, 6, 3, 7, 8, 0, 9, 0, 10, 0, 11, 0,
+    float result[1024] = {0, 4, 1, 5, 2, 6, 3, 7, 8, 0, 9, 0, 10, 0, 11, 0,
                            12, 16, 13, 17, 14, 18, 15, 19, 20, 0, 21, 0, 22, 0, 23, 0};
     test_repart_chunk(data->ctx, itemsize, backend, ndim, shape_, pshape_, spshape_, enforceframe, filename, result);
 }
@@ -186,8 +204,8 @@ LWTEST_FIXTURE(repart_chunk, 5_dim_blosc) {
     int64_t pshape_[] = {2, 2, 2, 2, 2};
     int64_t spshape_[] = {1, 1, 1, 1, 1};
     double result[1024];
-    for(double i = 0.0; i < 32; i++){
-        result[(int) i] = i;
+    for(int i = 0; i < 32; i++){
+        result[i] = (double) i;
     }
     test_repart_chunk(data->ctx, itemsize, backend, ndim, shape_, pshape_, spshape_, enforceframe, filename, result);
 }
@@ -208,16 +226,16 @@ LWTEST_FIXTURE(repart_chunk, 6_dim_pad) {
     test_repart_chunk(data->ctx, itemsize, backend, ndim, shape_, pshape_, spshape_, enforceframe, filename, result);
 }
 
-LWTEST_FIXTURE(repart_chunk, 7_dim_pad) {
+LWTEST_FIXTURE(repart_chunk, 7_dim_uint8) {
     const uint8_t ndim = 7;
-    uint8_t itemsize = sizeof(double );
+    uint8_t itemsize = sizeof(uint8_t);
     caterva_storage_backend_t backend = CATERVA_STORAGE_BLOSC;
     bool enforceframe = true;
     char *filename = NULL;
     int64_t shape_[] = {2, 3, 2, 3, 3, 2, 5};
     int64_t pshape_[] = {1, 2, 1, 2, 3, 2, 4};
     int64_t spshape_[] = {1, 2, 1, 2, 2, 1, 3};
-    double result[1024] = { 0, 1, 2, 8, 9, 10, 24, 25, 26, 32, 33, 34, 48, 49, 50, 56, 57, 58, 72, 73, 74, 80,
+    uint8_t result[1024] = { 0, 1, 2, 8, 9, 10, 24, 25, 26, 32, 33, 34, 48, 49, 50, 56, 57, 58, 72, 73, 74, 80,
                             81, 82, 3, 0, 0, 11, 0, 0, 27, 0, 0, 35, 0, 0, 51, 0, 0, 59, 0, 0, 75, 0, 0, 83, 0,
                             0, 4, 5, 6, 12, 13, 14, 28, 29, 30, 36, 37, 38, 52, 53, 54, 60, 61, 62, 76, 77, 78,
                             84, 85, 86, 7, 0, 0, 15, 0, 0, 31, 0, 0, 39, 0, 0, 55, 0, 0, 63, 0, 0, 79, 0, 0, 87,
@@ -228,7 +246,7 @@ LWTEST_FIXTURE(repart_chunk, 7_dim_pad) {
     test_repart_chunk(data->ctx, itemsize, backend, ndim, shape_, pshape_, spshape_, enforceframe, filename, result);
 }
 
-LWTEST_FIXTURE(repart_chunk, 8_dim_float) {
+LWTEST_FIXTURE(repart_chunk, 8_dim) {
     const uint8_t ndim = 8;
     uint8_t itemsize = sizeof(double );
     caterva_storage_backend_t backend = CATERVA_STORAGE_BLOSC;
@@ -237,6 +255,27 @@ LWTEST_FIXTURE(repart_chunk, 8_dim_float) {
     int64_t shape_[] = {1, 2, 1, 3, 3, 2, 2, 3};
     int64_t pshape_[] = {1, 2, 1, 2, 3, 2, 2, 3};
     int64_t spshape_[] = {1, 2, 1, 2, 2, 1, 2, 3};
-    double result[1024] = {0, 1, 2, 3, 4, 5, 12, 13, 14, 15, 16, 17, 36, 37, 38, 39, 40, 41, 48, 49, 50, 51, 52, 53, 72, 73, 74, 75, 76, 77, 84, 85, 86, 87, 88, 89, 108, 109, 110, 111, 112, 113, 120, 121, 122, 123, 124, 125, 6, 7, 8, 9, 10, 11, 18, 19, 20, 21, 22, 23, 42, 43, 44, 45, 46, 47, 54, 55, 56, 57, 58, 59, 78, 79, 80, 81, 82, 83, 90, 91, 92, 93, 94, 95, 114, 115, 116, 117, 118, 119, 126, 127, 128, 129, 130, 131, 24, 25, 26, 27, 28, 29, 0, 0, 0, 0, 0, 0, 60, 61, 62, 63, 64, 65, 0, 0, 0, 0, 0, 0, 96, 97, 98, 99, 100, 101, 0, 0, 0, 0, 0, 0, 132, 133, 134, 135, 136, 137, 0, 0, 0, 0, 0, 0, 30, 31, 32, 33, 34, 35, 0, 0, 0, 0, 0, 0, 66, 67, 68, 69, 70, 71, 0, 0, 0, 0, 0, 0, 102, 103, 104, 105, 106, 107, 0, 0, 0, 0, 0, 0, 138, 139, 140, 141, 142, 143, 0, 0, 0, 0, 0, 0};
+    double result[1024] = {0, 1, 2, 3, 4, 5, 12, 13, 14, 15, 16, 17, 36, 37, 38, 39, 40, 41, 48, 49, 50, 51,
+                           52, 53, 72, 73, 74, 75, 76, 77, 84, 85, 86, 87, 88, 89, 108, 109, 110, 111, 112,
+                           113, 120, 121, 122, 123, 124, 125, 6, 7, 8, 9, 10, 11, 18, 19, 20, 21, 22, 23, 42,
+                           43, 44, 45, 46, 47, 54, 55, 56, 57, 58, 59, 78, 79, 80, 81, 82, 83, 90, 91, 92, 93,
+                           94, 95, 114, 115, 116, 117, 118, 119, 126, 127, 128, 129, 130, 131, 24, 25, 26, 27,
+                           28, 29, 0, 0, 0, 0, 0, 0, 60, 61, 62, 63, 64, 65, 0, 0, 0, 0, 0, 0, 96, 97, 98, 99,
+                           100, 101, 0, 0, 0, 0, 0, 0, 132, 133, 134, 135, 136, 137, 0, 0, 0, 0, 0, 0, 30, 31,
+                           32, 33, 34, 35, 0, 0, 0, 0, 0, 0, 66, 67, 68, 69, 70, 71, 0, 0, 0, 0, 0, 0, 102, 103,
+                           104, 105, 106, 107, 0, 0, 0, 0, 0, 0, 138, 139, 140, 141, 142, 143, 0, 0, 0, 0, 0, 0};
+    test_repart_chunk(data->ctx, itemsize, backend, ndim, shape_, pshape_, spshape_, enforceframe, filename, result);
+}
+
+LWTEST_FIXTURE(repart_chunk, 8_dim_uint16) {
+    const uint8_t ndim = 8;
+    uint8_t itemsize = sizeof(uint16_t);
+    caterva_storage_backend_t backend = CATERVA_STORAGE_BLOSC;
+    bool enforceframe = false;
+    char *filename = NULL;
+    int64_t shape_[] = {1, 2, 1, 2, 1, 1, 2, 3};
+    int64_t pshape_[] = {1, 2, 1, 2, 1, 1, 2, 2};
+    int64_t spshape_[] = {1, 1, 1, 1, 1, 1, 2, 1};
+    uint16_t result[1024] = {0, 2, 1, 3, 4, 6, 5, 7, 8, 10, 9, 11, 12, 14, 13, 15};
     test_repart_chunk(data->ctx, itemsize, backend, ndim, shape_, pshape_, spshape_, enforceframe, filename, result);
 }

--- a/tests/test_repart_chunk.c
+++ b/tests/test_repart_chunk.c
@@ -176,7 +176,7 @@ LWTEST_FIXTURE(repart_chunk, 4_dim_pad) {
 }
 
 
-LWTEST_FIXTURE(repart_chunk, 5_dim_plain) {
+LWTEST_FIXTURE(repart_chunk, 5_dim_blosc) {
     const uint8_t ndim = 5;
     uint8_t itemsize = sizeof(double);
     caterva_storage_backend_t backend = CATERVA_STORAGE_BLOSC;
@@ -192,3 +192,51 @@ LWTEST_FIXTURE(repart_chunk, 5_dim_plain) {
     test_repart_chunk(data->ctx, itemsize, backend, ndim, shape_, pshape_, spshape_, enforceframe, filename, result);
 }
 
+LWTEST_FIXTURE(repart_chunk, 6_dim_pad) {
+    const uint8_t ndim = 6;
+    uint8_t itemsize = sizeof(double );
+    caterva_storage_backend_t backend = CATERVA_STORAGE_BLOSC;
+    bool enforceframe = true;
+    char *filename = NULL;
+    int64_t shape_[] = {2, 3, 2, 3, 3, 6};
+    int64_t pshape_[] = {1, 2, 1, 2, 3, 5};
+    int64_t spshape_[] = {1, 1, 1, 2, 2, 5};
+    double result[1024] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 10,
+                            11, 12, 13, 14, 0, 0, 0, 0, 0, 25, 26, 27, 28, 29, 0, 0, 0, 0, 0, 30, 31,
+                            32, 33, 34, 35, 36, 37, 38, 39, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54,
+                            40, 41, 42, 43, 44, 0, 0, 0, 0, 0, 55, 56, 57, 58, 59, 0, 0, 0, 0, 0};
+    test_repart_chunk(data->ctx, itemsize, backend, ndim, shape_, pshape_, spshape_, enforceframe, filename, result);
+}
+
+LWTEST_FIXTURE(repart_chunk, 7_dim_pad) {
+    const uint8_t ndim = 7;
+    uint8_t itemsize = sizeof(double );
+    caterva_storage_backend_t backend = CATERVA_STORAGE_BLOSC;
+    bool enforceframe = true;
+    char *filename = NULL;
+    int64_t shape_[] = {2, 3, 2, 3, 3, 2, 5};
+    int64_t pshape_[] = {1, 2, 1, 2, 3, 2, 4};
+    int64_t spshape_[] = {1, 2, 1, 2, 2, 1, 3};
+    double result[1024] = { 0, 1, 2, 8, 9, 10, 24, 25, 26, 32, 33, 34, 48, 49, 50, 56, 57, 58, 72, 73, 74, 80,
+                            81, 82, 3, 0, 0, 11, 0, 0, 27, 0, 0, 35, 0, 0, 51, 0, 0, 59, 0, 0, 75, 0, 0, 83, 0,
+                            0, 4, 5, 6, 12, 13, 14, 28, 29, 30, 36, 37, 38, 52, 53, 54, 60, 61, 62, 76, 77, 78,
+                            84, 85, 86, 7, 0, 0, 15, 0, 0, 31, 0, 0, 39, 0, 0, 55, 0, 0, 63, 0, 0, 79, 0, 0, 87,
+                            0, 0, 16, 17, 18, 0, 0, 0, 40, 41, 42, 0, 0, 0, 64, 65, 66, 0, 0, 0, 88, 89, 90, 0,
+                            0, 0, 19, 0, 0, 0, 0, 0, 43, 0, 0, 0, 0, 0, 67, 0, 0, 0, 0, 0, 91, 0, 0, 0, 0, 0, 20,
+                            21, 22, 0, 0, 0, 44, 45, 46, 0, 0, 0, 68, 69, 70, 0, 0, 0, 92, 93, 94, 0, 0, 0, 23,
+                            0, 0, 0, 0, 0, 47, 0, 0, 0, 0, 0, 71, 0, 0, 0, 0, 0, 95, 0, 0, 0, 0, 0};
+    test_repart_chunk(data->ctx, itemsize, backend, ndim, shape_, pshape_, spshape_, enforceframe, filename, result);
+}
+
+LWTEST_FIXTURE(repart_chunk, 8_dim_float) {
+    const uint8_t ndim = 8;
+    uint8_t itemsize = sizeof(double );
+    caterva_storage_backend_t backend = CATERVA_STORAGE_BLOSC;
+    bool enforceframe = false;
+    char *filename = NULL;
+    int64_t shape_[] = {1, 2, 1, 3, 3, 2, 2, 3};
+    int64_t pshape_[] = {1, 2, 1, 2, 3, 2, 2, 3};
+    int64_t spshape_[] = {1, 2, 1, 2, 2, 1, 2, 3};
+    double result[1024] = {0, 1, 2, 3, 4, 5, 12, 13, 14, 15, 16, 17, 36, 37, 38, 39, 40, 41, 48, 49, 50, 51, 52, 53, 72, 73, 74, 75, 76, 77, 84, 85, 86, 87, 88, 89, 108, 109, 110, 111, 112, 113, 120, 121, 122, 123, 124, 125, 6, 7, 8, 9, 10, 11, 18, 19, 20, 21, 22, 23, 42, 43, 44, 45, 46, 47, 54, 55, 56, 57, 58, 59, 78, 79, 80, 81, 82, 83, 90, 91, 92, 93, 94, 95, 114, 115, 116, 117, 118, 119, 126, 127, 128, 129, 130, 131, 24, 25, 26, 27, 28, 29, 0, 0, 0, 0, 0, 0, 60, 61, 62, 63, 64, 65, 0, 0, 0, 0, 0, 0, 96, 97, 98, 99, 100, 101, 0, 0, 0, 0, 0, 0, 132, 133, 134, 135, 136, 137, 0, 0, 0, 0, 0, 0, 30, 31, 32, 33, 34, 35, 0, 0, 0, 0, 0, 0, 66, 67, 68, 69, 70, 71, 0, 0, 0, 0, 0, 0, 102, 103, 104, 105, 106, 107, 0, 0, 0, 0, 0, 0, 138, 139, 140, 141, 142, 143, 0, 0, 0, 0, 0, 0};
+    test_repart_chunk(data->ctx, itemsize, backend, ndim, shape_, pshape_, spshape_, enforceframe, filename, result);
+}

--- a/tests/test_repart_chunk.c
+++ b/tests/test_repart_chunk.c
@@ -53,7 +53,8 @@ static void test_repart_chunk(caterva_context_t *ctx, uint8_t itemsize, caterva_
     if (res != 0) {
         printf("Error code : %d\n", res);
     }
-    for (int i = 0; i < carr->chunksize; ++i) {
+    printf("\n buffer dest \n");
+    for (int i = 0; i < carr->extendedchunksize; ++i) {
         printf("%f,", buffer_dest[i]);
     }
 
@@ -76,7 +77,7 @@ LWTEST_TEARDOWN(repart_chunk) {
     caterva_context_free(&data->ctx);
 }
 
-/*
+
 LWTEST_FIXTURE(repart_chunk, 2_dim) {
     const uint8_t ndim = 2;
     uint8_t itemsize = sizeof(double);
@@ -132,7 +133,7 @@ LWTEST_FIXTURE(repart_chunk, 3_dim_pad) {
     double result[1024] = {0, 2, 1, 3, 4, 0, 5, 0, 6, 8, 7, 9, 10, 0, 11, 0};
     test_repart_chunk(data->ctx, itemsize, backend, ndim, shape_, pshape_, spshape_, enforceframe, filename, result);
 }
-*/
+
 LWTEST_FIXTURE(repart_chunk, 3_dim_2) {
     const uint8_t ndim = 3;
     uint8_t itemsize = sizeof(double);
@@ -142,14 +143,14 @@ LWTEST_FIXTURE(repart_chunk, 3_dim_2) {
     int64_t shape_[] = {5, 6, 3};
     int64_t pshape_[] = {4, 3, 3};
     int64_t spshape_[] = {3, 3, 2};
-    double result[1024] = {0.000000, 1.000000, 3.000000, 4.000000, 6.000000, 7.000000, 18.000000, 19.000000, 21.000000,
-                           22.000000, 24.000000, 25.000000, 36.000000, 37.000000, 39.000000, 40.000000, 42.000000, 43.000000,
-                           2.000000, 0.000000, 5.000000, 0.000000, 8.000000, 0.000000, 20.000000, 0.000000, 23.000000,
-                           0.000000, 26.000000, 0.000000, 38.000000, 0.000000, 41.000000, 0.000000, 44.000000, 0.000000,
-                           54, 55, 57, 58, 60, 61, 0,0,0,0,0,0,0,0,0,0,0,0, 56, 0, 59, 0, 62, 0, 0,0,0,0,0,0,0,0,0,0,0,0};
+    double result[1024] = {0.000000, 1.000000, 3.000000, 4.000000, 6.000000, 7.000000, 9.000000, 10.000000, 12.000000,
+                           13.000000, 15.000000, 16.000000, 18.000000, 19.000000, 21.000000, 22.000000, 24.000000, 25.000000,
+                           2.000000, 0.000000, 5.000000, 0.000000, 8.000000, 0.000000, 11.000000, 0.000000, 14.000000,
+                           0.000000, 17.000000, 0.000000, 20.000000, 0.000000, 23.000000, 0.000000, 26.000000, 0.000000,
+                           27, 28, 30, 31, 33, 34, 0,0,0,0,0,0,0,0,0,0,0,0, 29, 0, 32, 0, 35, 0, 0,0,0,0,0,0,0,0,0,0,0,0};
     test_repart_chunk(data->ctx, itemsize, backend, ndim, shape_, pshape_, spshape_, enforceframe, filename, result);
 }
-/*
+
 LWTEST_FIXTURE(repart_chunk, 4_dim) {
     const uint8_t ndim = 4;
     uint8_t itemsize = sizeof(double);
@@ -193,4 +194,4 @@ LWTEST_FIXTURE(repart_chunk, 5_dim_plain) {
     }
     test_repart_chunk(data->ctx, itemsize, backend, ndim, shape_, pshape_, spshape_, enforceframe, filename, result);
 }
-*/
+

--- a/tests/test_repart_chunk.c
+++ b/tests/test_repart_chunk.c
@@ -44,7 +44,7 @@ static void test_repart_chunk(caterva_context_t *ctx, uint8_t itemsize, caterva_
 
     /* Fill empty caterva_array_t with blocks */
     int size_src = carr->chunksize * itemsize;
-    int size_dest = carr->extendedchunksize * itemsize;
+    int size_dest = carr->extchunksize * itemsize;
     double *buffer_src = (double *) ctx->cfg->alloc(size_src);
     double *buffer_dest = (double *) ctx->cfg->alloc(size_dest);
     for (int i = 0; i < carr->chunksize; ++i) {
@@ -55,7 +55,7 @@ static void test_repart_chunk(caterva_context_t *ctx, uint8_t itemsize, caterva_
         printf("Error code : %d\n", res);
     }
 
-    assert_buf((uint8_t*) buffer_dest, (uint8_t*) result, itemsize, (size_t)carr->extendedchunksize, 1e-8);   // tam epsize*typesize????????????????
+    assert_buf((uint8_t*) buffer_dest, (uint8_t*) result, itemsize, (size_t)carr->extchunksize, 1e-8);   // tam epsize*typesize????????????????
     ctx->cfg->free(buffer_src);
     ctx->cfg->free(buffer_dest);
     CATERVA_TEST_ERROR(caterva_array_free(ctx, &carr));

--- a/tests/test_repart_chunk.c
+++ b/tests/test_repart_chunk.c
@@ -76,7 +76,7 @@ LWTEST_TEARDOWN(repart_chunk) {
     caterva_context_free(&data->ctx);
 }
 
-
+/*
 LWTEST_FIXTURE(repart_chunk, 2_dim) {
     const uint8_t ndim = 2;
     uint8_t itemsize = sizeof(double);
@@ -132,8 +132,24 @@ LWTEST_FIXTURE(repart_chunk, 3_dim_pad) {
     double result[1024] = {0, 2, 1, 3, 4, 0, 5, 0, 6, 8, 7, 9, 10, 0, 11, 0};
     test_repart_chunk(data->ctx, itemsize, backend, ndim, shape_, pshape_, spshape_, enforceframe, filename, result);
 }
-
-
+*/
+LWTEST_FIXTURE(repart_chunk, 3_dim_2) {
+    const uint8_t ndim = 3;
+    uint8_t itemsize = sizeof(double);
+    caterva_storage_backend_t backend = CATERVA_STORAGE_BLOSC;
+    bool enforceframe = true;
+    char *filename = NULL;
+    int64_t shape_[] = {5, 6, 3};
+    int64_t pshape_[] = {4, 3, 3};
+    int64_t spshape_[] = {3, 3, 2};
+    double result[1024] = {0.000000, 1.000000, 3.000000, 4.000000, 6.000000, 7.000000, 18.000000, 19.000000, 21.000000,
+                           22.000000, 24.000000, 25.000000, 36.000000, 37.000000, 39.000000, 40.000000, 42.000000, 43.000000,
+                           2.000000, 0.000000, 5.000000, 0.000000, 8.000000, 0.000000, 20.000000, 0.000000, 23.000000,
+                           0.000000, 26.000000, 0.000000, 38.000000, 0.000000, 41.000000, 0.000000, 44.000000, 0.000000,
+                           54, 55, 57, 58, 60, 61, 0,0,0,0,0,0,0,0,0,0,0,0, 56, 0, 59, 0, 62, 0, 0,0,0,0,0,0,0,0,0,0,0,0};
+    test_repart_chunk(data->ctx, itemsize, backend, ndim, shape_, pshape_, spshape_, enforceframe, filename, result);
+}
+/*
 LWTEST_FIXTURE(repart_chunk, 4_dim) {
     const uint8_t ndim = 4;
     uint8_t itemsize = sizeof(double);
@@ -177,4 +193,4 @@ LWTEST_FIXTURE(repart_chunk, 5_dim_plain) {
     }
     test_repart_chunk(data->ctx, itemsize, backend, ndim, shape_, pshape_, spshape_, enforceframe, filename, result);
 }
-
+*/

--- a/tests/test_repart_chunk.c
+++ b/tests/test_repart_chunk.c
@@ -15,6 +15,7 @@ static void test_repart_chunk(caterva_context_t *ctx, uint8_t itemsize, caterva_
                               int64_t *shape_, int64_t *chunkshape, int64_t *blockshape, bool enforceframe,
                               char *filename, double result[]) {
 
+
     caterva_params_t params;
     params.itemsize = itemsize;
     params.ndim = ndim;

--- a/tests/test_repart_chunk.c
+++ b/tests/test_repart_chunk.c
@@ -10,6 +10,7 @@
  */
 
 #include "test_common.h"
+#include "caterva_blosc.h"
 
 static void test_repart_chunk(caterva_context_t *ctx, uint8_t itemsize, caterva_storage_backend_t backend, uint8_t ndim,
                               int64_t *shape_, int64_t *chunkshape, int64_t *blockshape, bool enforceframe,
@@ -44,8 +45,8 @@ static void test_repart_chunk(caterva_context_t *ctx, uint8_t itemsize, caterva_
     /* Fill empty caterva_array_t with blocks */
     int size_src = carr->chunksize * itemsize;
     int size_dest = carr->extendedchunksize * itemsize;
-    double *buffer_src = (double *) malloc(size_src);
-    double *buffer_dest = (double *) malloc(size_dest);
+    double *buffer_src = (double *) ctx->cfg->alloc(size_src);
+    double *buffer_dest = (double *) ctx->cfg->alloc(size_dest);
     for (int i = 0; i < carr->chunksize; ++i) {
         buffer_src[i] =  (double) i;
     }
@@ -53,14 +54,10 @@ static void test_repart_chunk(caterva_context_t *ctx, uint8_t itemsize, caterva_
     if (res != 0) {
         printf("Error code : %d\n", res);
     }
-    printf("\n buffer dest \n");
-    for (int i = 0; i < carr->extendedchunksize; ++i) {
-        printf("%f,", buffer_dest[i]);
-    }
 
     assert_buf((uint8_t*) buffer_dest, (uint8_t*) result, itemsize, (size_t)carr->extendedchunksize, 1e-8);   // tam epsize*typesize????????????????
-    free(buffer_src);
-    free(buffer_dest);
+    ctx->cfg->free(buffer_src);
+    ctx->cfg->free(buffer_dest);
     CATERVA_TEST_ERROR(caterva_array_free(ctx, &carr));
 }
 

--- a/tests/test_repart_chunk.c
+++ b/tests/test_repart_chunk.c
@@ -1,0 +1,179 @@
+/*
+ * Copyright (C) 2018 Francesc Alted, Aleix Alcacer.
+ * Copyright (C) 2019-present Blosc Development team <blosc@blosc.org>
+ * All rights reserved.
+ *
+ * This source code is licensed under both the BSD-style license (found in the
+ * LICENSE file in the root directory of this source tree) and the GPLv2 (found
+ * in the COPYING file in the root directory of this source tree).
+ * You may select, at your option, one of the above-listed licenses.
+ */
+
+#include "test_common.h"
+
+static void test_repart_chunk(caterva_context_t *ctx, uint8_t itemsize, caterva_storage_backend_t backend, uint8_t ndim,
+                              int64_t *shape_, int64_t *chunkshape, int64_t *blockshape, bool enforceframe,
+                              char *filename, double result[]) {
+
+    caterva_params_t params;
+    params.itemsize = itemsize;
+    params.ndim = ndim;
+    for (int i = 0; i < ndim; ++i) {
+        params.shape[i] = shape_[i];
+    }
+    caterva_storage_t storage;
+    storage.properties.blosc.filename = filename;
+    storage.properties.blosc.enforceframe = enforceframe;
+    storage.backend = backend;
+    switch (backend) {
+        case CATERVA_STORAGE_PLAINBUFFER:
+            break;
+        case CATERVA_STORAGE_BLOSC:
+            for (int i = 0; i < ndim; ++i) {
+                storage.properties.blosc.chunkshape[i] = chunkshape[i];
+                storage.properties.blosc.blockshape[i] = blockshape[i];
+            }
+            break;
+        default:
+            CATERVA_TEST_ERROR(CATERVA_ERR_INVALID_STORAGE);
+    }
+    caterva_array_t *carr;
+    caterva_array_empty(ctx, &params, &storage, &carr);
+
+    /* Fill empty caterva_array_t with blocks */
+    int size_src = carr->chunksize * itemsize;
+    int size_dest = carr->extendedchunksize * itemsize;
+    double *buffer_src = (double *) malloc(size_src);
+    double *buffer_dest = (double *) malloc(size_dest);
+    for (int i = 0; i < carr->chunksize; ++i) {
+        buffer_src[i] =  (double) i;
+    }
+    int res = caterva_blosc_array_repart_chunk((int8_t *) buffer_dest, size_dest, buffer_src, size_src, carr);
+    if (res != 0) {
+        printf("Error code : %d\n", res);
+    }
+    for (int i = 0; i < carr->chunksize; ++i) {
+        printf("%f,", buffer_dest[i]);
+    }
+
+    assert_buf((uint8_t*) buffer_dest, (uint8_t*) result, itemsize, (size_t)carr->extendedchunksize, 1e-8);   // tam epsize*typesize????????????????
+    free(buffer_src);
+    free(buffer_dest);
+    CATERVA_TEST_ERROR(caterva_array_free(ctx, &carr));
+}
+
+LWTEST_DATA(repart_chunk) {
+    caterva_context_t *ctx;
+};
+
+LWTEST_SETUP(repart_chunk) {
+    caterva_config_t cfg = CATERVA_CONFIG_DEFAULTS;
+    caterva_context_new(&cfg, &data->ctx);
+}
+
+LWTEST_TEARDOWN(repart_chunk) {
+    caterva_context_free(&data->ctx);
+}
+
+
+LWTEST_FIXTURE(repart_chunk, 2_dim) {
+    const uint8_t ndim = 2;
+    uint8_t itemsize = sizeof(double);
+    caterva_storage_backend_t backend = CATERVA_STORAGE_BLOSC;
+    bool enforceframe = true;
+    char *filename = NULL;
+    int64_t shape_[] = {8, 16};
+    int64_t pshape_[] = {4, 8};
+    int64_t spshape_[] = {2, 4};
+    double result[1024] = {0, 1, 2, 3, 8, 9, 10, 11, 4, 5, 6, 7, 12, 13,
+                           14, 15, 16, 17, 18, 19, 24, 25, 26, 27, 20, 21, 22, 23, 28, 29, 30, 31};
+
+    test_repart_chunk(data->ctx, itemsize, backend, ndim, shape_, pshape_, spshape_, enforceframe, filename, result);
+}
+
+LWTEST_FIXTURE(repart_chunk, 2_dim_pad) {
+    const uint8_t ndim = 2;
+    uint8_t itemsize = sizeof(double);
+    caterva_storage_backend_t backend = CATERVA_STORAGE_BLOSC;
+    bool enforceframe = true;
+    char *filename = NULL;
+    int64_t shape__[] = {8, 16};
+    int64_t pshape__[] = {4, 8};
+    int64_t spshape__[] = {2, 3};
+    double result[1024] = {0, 1, 2, 8, 9, 10, 3, 4, 5, 11, 12, 13, 6, 7, 0, 14, 15, 0,
+                           16, 17, 18, 24, 25, 26, 19, 20, 21, 27, 28, 29, 22, 23, 0, 30, 31, 0};
+    test_repart_chunk(data->ctx, itemsize, backend, ndim, shape__, pshape__, spshape__, enforceframe, filename, result);
+}
+
+
+LWTEST_FIXTURE(repart_chunk, 3_dim) {
+    const uint8_t ndim = 3;
+    uint8_t itemsize = sizeof(double);
+    caterva_storage_backend_t backend = CATERVA_STORAGE_BLOSC;
+    bool enforceframe = true;
+    char *filename = NULL;
+    int64_t shape_[] = {4, 3, 2};
+    int64_t pshape_[] = {2, 2, 2};
+    int64_t spshape_[] = {1, 2, 1};
+    double result[1024] = {0, 2, 1, 3, 4, 6, 5, 7};
+    test_repart_chunk(data->ctx, itemsize, backend, ndim, shape_, pshape_, spshape_, enforceframe, filename, result);
+}
+
+LWTEST_FIXTURE(repart_chunk, 3_dim_pad) {
+    const uint8_t ndim = 3;
+    uint8_t itemsize = sizeof(double);
+    caterva_storage_backend_t backend = CATERVA_STORAGE_BLOSC;
+    bool enforceframe = true;
+    char *filename = NULL;
+    int64_t shape_[] = {4, 3, 2};
+    int64_t pshape_[] = {2, 3, 2};
+    int64_t spshape_[] = {1, 2, 1};
+    double result[1024] = {0, 2, 1, 3, 4, 0, 5, 0, 6, 8, 7, 9, 10, 0, 11, 0};
+    test_repart_chunk(data->ctx, itemsize, backend, ndim, shape_, pshape_, spshape_, enforceframe, filename, result);
+}
+
+
+LWTEST_FIXTURE(repart_chunk, 4_dim) {
+    const uint8_t ndim = 4;
+    uint8_t itemsize = sizeof(double);
+    caterva_storage_backend_t backend = CATERVA_STORAGE_BLOSC;
+    bool enforceframe = true;
+    char *filename = NULL;
+    int64_t shape_[] = {4, 3, 5, 4};
+    int64_t pshape_[] = {2, 2, 2, 2};
+    int64_t spshape_[] = {1, 2, 1, 1};
+    double result[1024] = {0, 4, 1, 5, 2, 6, 3, 7, 8, 12, 9, 13, 10, 14, 11, 15};
+    test_repart_chunk(data->ctx, itemsize, backend, ndim, shape_, pshape_, spshape_, enforceframe, filename, result);
+}
+
+LWTEST_FIXTURE(repart_chunk, 4_dim_pad) {
+    const uint8_t ndim = 4;
+    uint8_t itemsize = sizeof(double);
+    caterva_storage_backend_t backend = CATERVA_STORAGE_BLOSC;
+    bool enforceframe = true;
+    char *filename = NULL;
+    int64_t shape_[] = {4, 3, 2, 6};
+    int64_t pshape_[] = {2, 3, 2, 2};
+    int64_t spshape_[] = {1, 2, 1, 1};
+    double result[1024] = {0, 4, 1, 5, 2, 6, 3, 7, 8, 0, 9, 0, 10, 0, 11, 0,
+                           12, 16, 13, 17, 14, 18, 15, 19, 20, 0, 21, 0, 22, 0, 23, 0};
+    test_repart_chunk(data->ctx, itemsize, backend, ndim, shape_, pshape_, spshape_, enforceframe, filename, result);
+}
+
+
+LWTEST_FIXTURE(repart_chunk, 5_dim_plain) {
+    const uint8_t ndim = 5;
+    uint8_t itemsize = sizeof(double);
+    caterva_storage_backend_t backend = CATERVA_STORAGE_BLOSC;
+    bool enforceframe = true;
+    char *filename = NULL;
+    int64_t shape_[] = {14, 23, 12, 11, 8};
+    int64_t pshape_[] = {2, 2, 2, 2, 2};
+    int64_t spshape_[] = {1, 1, 1, 1, 1};
+    double result[1024];
+    for(double i = 0.0; i < 32; i++){
+        result[(int) i] = i;
+    }
+    test_repart_chunk(data->ctx, itemsize, backend, ndim, shape_, pshape_, spshape_, enforceframe, filename, result);
+}
+

--- a/tests/test_roundtrip.c
+++ b/tests/test_roundtrip.c
@@ -79,8 +79,23 @@ LWTEST_TEARDOWN(roundtrip) {
     caterva_context_free(&data->ctx);
 }
 
-LWTEST_FIXTURE(roundtrip, 3_double_plainbuffer) {
-    uint8_t itemsize = sizeof(double);
+
+LWTEST_FIXTURE(roundtrip, 1_uint16_plainbuffer) {
+    uint8_t itemsize = sizeof(uint16_t);
+    uint8_t ndim = 1;
+    int64_t shape[] = {7};
+
+    caterva_storage_backend_t backend = CATERVA_STORAGE_PLAINBUFFER;
+    int64_t chunkshape[] = {0};
+    int64_t blockshape[] = {0};
+    bool enforceframe = false;
+    char *filename = NULL;
+
+    test_roundtrip(data->ctx, itemsize, ndim, shape, backend, chunkshape, blockshape, enforceframe, filename);
+}
+
+LWTEST_FIXTURE(roundtrip, 2_uint8_plainbuffer) {
+    uint8_t itemsize = sizeof(uint8_t);
     uint8_t ndim = 2;
     int64_t shape[] = {4, 3};
 
@@ -124,8 +139,8 @@ LWTEST_FIXTURE(roundtrip, 4_float_blosc) {
     test_roundtrip(data->ctx, itemsize, ndim, shape, backend, chunkshape, blockshape, enforceframe, filename);
 }
 
-LWTEST_FIXTURE(roundtrip, 4_double_plainbuffer) {
-    uint8_t itemsize = sizeof(double);
+LWTEST_FIXTURE(roundtrip, 4_uint8_plainbuffer) {
+    uint8_t itemsize = sizeof(uint8_t);
     uint8_t ndim = 4;
     int64_t shape[] = {78, 85, 34, 56};
 
@@ -166,8 +181,8 @@ LWTEST_FIXTURE(roundtrip, 5_double_plainbuffer) {
     test_roundtrip(data->ctx, itemsize, ndim, shape, backend, chunkshape, blockshape, enforceframe, filename);
 }
 
-LWTEST_FIXTURE(roundtrip, 6_float_blosc) {
-    uint8_t itemsize = sizeof(float);
+LWTEST_FIXTURE(roundtrip, 6_uint16_blosc) {
+    uint8_t itemsize = sizeof(uint16_t);
     uint8_t ndim = 6;
     int64_t shape[] = {4, 3, 8, 5, 10, 12};
 
@@ -194,8 +209,8 @@ LWTEST_FIXTURE(roundtrip, 7_double_plainbuffer) {
     test_roundtrip(data->ctx, itemsize, ndim, shape, backend, chunkshape, blockshape, enforceframe, filename);
 }
 
-LWTEST_FIXTURE(roundtrip, 8_float_blosc) {
-    uint8_t itemsize = sizeof(float);
+LWTEST_FIXTURE(roundtrip, 8_uint8_blosc) {
+    uint8_t itemsize = sizeof(uint8_t);
     uint8_t ndim = 8;
     int64_t shape[] = {4, 3, 8, 5, 10, 12, 6, 4};
 

--- a/tests/test_roundtrip.c
+++ b/tests/test_roundtrip.c
@@ -12,8 +12,8 @@
 #include "test_common.h"
 
 static void test_roundtrip(caterva_context_t *ctx, uint8_t itemsize, uint8_t ndim, int64_t *shape,
-                           caterva_storage_backend_t backend, int64_t *chunkshape, bool enforceframe,
-                           char *filename) {
+                           caterva_storage_backend_t backend, int64_t *chunkshape, int64_t *blockshape,
+                           bool enforceframe, char *filename) {
 
     caterva_params_t params;
     params.itemsize = itemsize;
@@ -32,6 +32,7 @@ static void test_roundtrip(caterva_context_t *ctx, uint8_t itemsize, uint8_t ndi
             storage.properties.blosc.enforceframe = enforceframe;
             for (int i = 0; i < ndim; ++i) {
                 storage.properties.blosc.chunkshape[i] = chunkshape[i];
+                storage.properties.blosc.blockshape[i] = blockshape[i];
             }
             break;
         default:
@@ -85,10 +86,11 @@ LWTEST_FIXTURE(roundtrip, 3_double_plainbuffer) {
 
     caterva_storage_backend_t backend = CATERVA_STORAGE_PLAINBUFFER;
     int64_t chunkshape[] = {0};
+    int64_t blockshape[] = {0};
     bool enforceframe = false;
     char *filename = NULL;
 
-    test_roundtrip(data->ctx, itemsize, ndim, shape, backend, chunkshape, enforceframe, filename);
+    test_roundtrip(data->ctx, itemsize, ndim, shape, backend, chunkshape, blockshape, enforceframe, filename);
 }
 
 
@@ -99,10 +101,11 @@ LWTEST_FIXTURE(roundtrip, 3_double_blosc) {
 
     caterva_storage_backend_t backend = CATERVA_STORAGE_BLOSC;
     int64_t chunkshape[] = {26, 17, 34};
+    int64_t blockshape[] = {11, 8, 13};
     bool enforceframe = false;
     char *filename = NULL;
 
-    test_roundtrip(data->ctx, itemsize, ndim, shape, backend, chunkshape, enforceframe, filename);
+    test_roundtrip(data->ctx, itemsize, ndim, shape, backend, chunkshape, blockshape, enforceframe, filename);
 
 }
 
@@ -114,10 +117,11 @@ LWTEST_FIXTURE(roundtrip, 4_float_blosc) {
 
     caterva_storage_backend_t backend = CATERVA_STORAGE_BLOSC;
     int64_t chunkshape[] = {2, 2, 3, 3};
+    int64_t blockshape[] = {2, 2, 2, 3};
     bool enforceframe = false;
     char *filename = NULL;
 
-    test_roundtrip(data->ctx, itemsize, ndim, shape, backend, chunkshape, enforceframe, filename);
+    test_roundtrip(data->ctx, itemsize, ndim, shape, backend, chunkshape, blockshape, enforceframe, filename);
 }
 
 LWTEST_FIXTURE(roundtrip, 4_double_plainbuffer) {
@@ -127,10 +131,11 @@ LWTEST_FIXTURE(roundtrip, 4_double_plainbuffer) {
 
     caterva_storage_backend_t backend = CATERVA_STORAGE_PLAINBUFFER;
     int64_t chunkshape[] = {0};
+    int64_t blockshape[] = {0};
     bool enforceframe = false;
     char *filename = NULL;
 
-    test_roundtrip(data->ctx, itemsize, ndim, shape, backend, chunkshape, enforceframe, filename);
+    test_roundtrip(data->ctx, itemsize, ndim, shape, backend, chunkshape, blockshape, enforceframe, filename);
 }
 
 LWTEST_FIXTURE(roundtrip, 5_float_blosc_frame) {
@@ -140,10 +145,11 @@ LWTEST_FIXTURE(roundtrip, 5_float_blosc_frame) {
 
     caterva_storage_backend_t backend = CATERVA_STORAGE_BLOSC;
     int64_t chunkshape[] = {2, 2, 3, 3, 4};
+    int64_t blockshape[] = {2, 1, 2, 2, 3};
     bool enforceframe = true;
     char *filename = NULL;
 
-    test_roundtrip(data->ctx, itemsize, ndim, shape, backend, chunkshape, enforceframe, filename);
+    test_roundtrip(data->ctx, itemsize, ndim, shape, backend, chunkshape, blockshape, enforceframe, filename);
 }
 
 LWTEST_FIXTURE(roundtrip, 5_double_plainbuffer) {
@@ -153,10 +159,11 @@ LWTEST_FIXTURE(roundtrip, 5_double_plainbuffer) {
 
     caterva_storage_backend_t backend = CATERVA_STORAGE_PLAINBUFFER;
     int64_t chunkshape[] = {0};
+    int64_t blockshape[] = {0};
     bool enforceframe = false;
     char *filename = NULL;
 
-    test_roundtrip(data->ctx, itemsize, ndim, shape, backend, chunkshape, enforceframe, filename);
+    test_roundtrip(data->ctx, itemsize, ndim, shape, backend, chunkshape, blockshape, enforceframe, filename);
 }
 
 LWTEST_FIXTURE(roundtrip, 6_float_blosc) {
@@ -166,10 +173,11 @@ LWTEST_FIXTURE(roundtrip, 6_float_blosc) {
 
     caterva_storage_backend_t backend = CATERVA_STORAGE_BLOSC;
     int64_t chunkshape[] = {2, 2, 3, 3, 4, 5};
+    int64_t blockshape[] = {2, 1, 2, 2, 3, 4};
     bool enforceframe = false;
     char *filename = NULL;
 
-    test_roundtrip(data->ctx, itemsize, ndim, shape, backend, chunkshape, enforceframe, filename);
+    test_roundtrip(data->ctx, itemsize, ndim, shape, backend, chunkshape, blockshape, enforceframe, filename);
 }
 
 LWTEST_FIXTURE(roundtrip, 7_double_plainbuffer) {
@@ -179,10 +187,11 @@ LWTEST_FIXTURE(roundtrip, 7_double_plainbuffer) {
 
     caterva_storage_backend_t backend = CATERVA_STORAGE_PLAINBUFFER;
     int64_t chunkshape[] = {0};
+    int64_t blockshape[] = {0};
     bool enforceframe = false;
     char *filename = NULL;
 
-    test_roundtrip(data->ctx, itemsize, ndim, shape, backend, chunkshape, enforceframe, filename);
+    test_roundtrip(data->ctx, itemsize, ndim, shape, backend, chunkshape, blockshape, enforceframe, filename);
 }
 
 LWTEST_FIXTURE(roundtrip, 8_float_blosc) {
@@ -192,8 +201,9 @@ LWTEST_FIXTURE(roundtrip, 8_float_blosc) {
 
     caterva_storage_backend_t backend = CATERVA_STORAGE_BLOSC;
     int64_t chunkshape[] = {3, 2, 3, 3, 4, 5, 4, 2};
+    int64_t blockshape[] = {2, 1, 2, 2, 3, 4, 3, 1};
     bool enforceframe = false;
     char *filename = NULL;
 
-    test_roundtrip(data->ctx, itemsize, ndim, shape, backend, chunkshape, enforceframe, filename);
+    test_roundtrip(data->ctx, itemsize, ndim, shape, backend, chunkshape, blockshape, enforceframe, filename);
 }

--- a/tests/test_roundtrip.c
+++ b/tests/test_roundtrip.c
@@ -137,7 +137,7 @@ LWTEST_FIXTURE(roundtrip, 4_double_plainbuffer) {
 
     test_roundtrip(data->ctx, itemsize, ndim, shape, backend, chunkshape, blockshape, enforceframe, filename);
 }
-
+/*
 LWTEST_FIXTURE(roundtrip, 5_float_blosc_frame) {
     uint8_t itemsize = sizeof(float);
     uint8_t ndim = 5;
@@ -151,7 +151,7 @@ LWTEST_FIXTURE(roundtrip, 5_float_blosc_frame) {
 
     test_roundtrip(data->ctx, itemsize, ndim, shape, backend, chunkshape, blockshape, enforceframe, filename);
 }
-
+*/
 LWTEST_FIXTURE(roundtrip, 5_double_plainbuffer) {
     uint8_t itemsize = sizeof(double);
     uint8_t ndim = 5;

--- a/tests/test_squeeze.c
+++ b/tests/test_squeeze.c
@@ -98,6 +98,30 @@ LWTEST_TEARDOWN(squeeze) {
     caterva_context_free(&data->ctx);
 }
 
+LWTEST_FIXTURE(squeeze, 2_double_blosc_plainbuffer) {
+    int64_t start[] = {5, 20};
+    int64_t stop[] = {23, 21};
+
+    uint8_t itemsize = sizeof(double );
+    uint8_t ndim = 2;
+    int64_t shape[] = {100, 100};
+
+    caterva_storage_backend_t backend = CATERVA_STORAGE_BLOSC;
+    int64_t chunkshape[] = {10, 10};
+    int64_t blockshape[] = {5, 6};
+    bool enforceframe = false;
+    char *filename = NULL;
+
+    caterva_storage_backend_t backend2 = CATERVA_STORAGE_PLAINBUFFER;
+    int64_t chunkshape2[] = {0};
+    int64_t blockshape2[] = {0};
+    bool enforceframe2 = false;
+    char *filename2 = NULL;
+
+    test_squeeze(data->ctx, itemsize, ndim, shape, backend, chunkshape, blockshape, enforceframe, filename,
+                 backend2, chunkshape2, blockshape2, enforceframe2, filename2, start, stop);
+}
+
 LWTEST_FIXTURE(squeeze, 3_float_blosc_blosc) {
     int64_t start[] = {5, 20, 60};
     int64_t stop[] = {23, 21, 99};
@@ -122,6 +146,30 @@ LWTEST_FIXTURE(squeeze, 3_float_blosc_blosc) {
         backend2, chunkshape2, blockshape2, enforceframe2, filename2, start, stop);
 }
 
+LWTEST_FIXTURE(squeeze, 4_float_plainbuffer_blosc) {
+    int64_t start[] = {5, 20, 10, 60};
+    int64_t stop[] = {23, 21, 33, 99};
+
+    uint8_t itemsize = sizeof(float);
+    uint8_t ndim = 4;
+    int64_t shape[] = {100, 100, 100, 100};
+
+    caterva_storage_backend_t backend = CATERVA_STORAGE_PLAINBUFFER;
+    int64_t chunkshape[] = {0};
+    int64_t blockshape[] = {0};
+    bool enforceframe = false;
+    char *filename = NULL;
+
+    caterva_storage_backend_t backend2 = CATERVA_STORAGE_BLOSC;
+    int64_t chunkshape2[] = {21, 1, 3, 12};
+    int64_t blockshape2[] = {8, 1, 2, 5};
+    bool enforceframe2 = false;
+    char *filename2 = NULL;
+
+    test_squeeze(data->ctx, itemsize, ndim, shape, backend, chunkshape, blockshape, enforceframe, filename,
+                 backend2, chunkshape2, blockshape2, enforceframe2, filename2, start, stop);
+}
+
 
 LWTEST_FIXTURE(squeeze, 5_double_plainbuffer_plainbuffer) {
     int64_t start[] = {1, 12, 3, 12, 6};
@@ -141,6 +189,30 @@ LWTEST_FIXTURE(squeeze, 5_double_plainbuffer_plainbuffer) {
     int64_t chunkshape2[] = {0};
     int64_t blockshape2[] = {0};
     bool enforceframe2 = false;
+    char *filename2 = NULL;
+
+    test_squeeze(data->ctx, itemsize, ndim, shape, backend, chunkshape, blockshape, enforceframe, filename,
+                 backend2, chunkshape2, blockshape2, enforceframe2, filename2, start, stop);
+}
+
+LWTEST_FIXTURE(squeeze, 6_float_blosc_plainbuffer_frame) {
+    int64_t start[] = {3, 3, 2, 1, 0, 4};
+    int64_t stop[] = {8, 10, 5, 2, 1, 9};
+
+    uint8_t itemsize = sizeof(float);
+    uint8_t ndim = 6;
+    int64_t shape[] = {8, 12, 6, 7, 6, 9};
+
+    caterva_storage_backend_t backend = CATERVA_STORAGE_PLAINBUFFER;
+    int64_t chunkshape[] = {0};
+    int64_t blockshape[] = {0};
+    bool enforceframe = false;
+    char *filename = NULL;
+
+    caterva_storage_backend_t backend2 = CATERVA_STORAGE_BLOSC;
+    int64_t chunkshape2[] = {3, 5, 2, 4, 3, 2};
+    int64_t blockshape2[] = {2, 3, 2, 3, 2, 1};
+    bool enforceframe2 = true;
     char *filename2 = NULL;
 
     test_squeeze(data->ctx, itemsize, ndim, shape, backend, chunkshape, blockshape, enforceframe, filename,

--- a/tests/test_squeeze.c
+++ b/tests/test_squeeze.c
@@ -33,8 +33,8 @@ static void test_squeeze(caterva_context_t *ctx, uint8_t itemsize, uint8_t ndim,
             storage.properties.blosc.filename = filename;
             storage.properties.blosc.enforceframe = enforceframe;
             for (int i = 0; i < ndim; ++i) {
-                storage.properties.blosc.chunkshape[i] = chunkshape[i];
-                storage.properties.blosc.blockshape[i] = blockshape[i];
+                storage.properties.blosc.chunkshape[i] = (int32_t) chunkshape[i];
+                storage.properties.blosc.blockshape[i] = (int32_t) blockshape[i];
             }
             break;
         default:

--- a/tests/test_squeeze.c
+++ b/tests/test_squeeze.c
@@ -137,7 +137,7 @@ LWTEST_FIXTURE(squeeze, 3_float_blosc_blosc) {
     char *filename = NULL;
 
     caterva_storage_backend_t backend2 = CATERVA_STORAGE_BLOSC;
-    int64_t chunkshape2[] = {21, 1, 12};
+    int64_t chunkshape2[] = {21, 1, 10};
     int64_t blockshape2[] = {8, 1, 5};
     bool enforceframe2 = false;
     char *filename2 = NULL;

--- a/tests/test_squeeze.c
+++ b/tests/test_squeeze.c
@@ -12,9 +12,9 @@
 #include "test_common.h"
 
 static void test_squeeze(caterva_context_t *ctx, uint8_t itemsize, uint8_t ndim, int64_t *shape,
-                         caterva_storage_backend_t backend, int64_t *chunkshape, bool enforceframe, char *filename,
-                         caterva_storage_backend_t backend2, int64_t *chunkshape2, bool enforceframe2, char *filename2,
-                         int64_t *start, int64_t *stop) {
+                         caterva_storage_backend_t backend, int64_t *chunkshape, int64_t *blockshape, bool enforceframe, 
+                         char *filename, caterva_storage_backend_t backend2, int64_t *chunkshape2, int64_t *blockshape2,
+                         bool enforceframe2, char *filename2, int64_t *start, int64_t *stop) {
 
 
     caterva_params_t params;
@@ -34,6 +34,7 @@ static void test_squeeze(caterva_context_t *ctx, uint8_t itemsize, uint8_t ndim,
             storage.properties.blosc.enforceframe = enforceframe;
             for (int i = 0; i < ndim; ++i) {
                 storage.properties.blosc.chunkshape[i] = chunkshape[i];
+                storage.properties.blosc.blockshape[i] = blockshape[i];
             }
             break;
         default:
@@ -65,6 +66,7 @@ static void test_squeeze(caterva_context_t *ctx, uint8_t itemsize, uint8_t ndim,
             storage2.properties.blosc.enforceframe = enforceframe2;
             for (int i = 0; i < ndim; ++i) {
                 storage2.properties.blosc.chunkshape[i] = chunkshape2[i];
+                storage2.properties.blosc.blockshape[i] = blockshape2[i];
             }
             break;
         default:
@@ -106,16 +108,18 @@ LWTEST_FIXTURE(squeeze, 3_float_blosc_blosc) {
 
     caterva_storage_backend_t backend = CATERVA_STORAGE_BLOSC;
     int64_t chunkshape[] = {10, 10, 10};
+    int64_t blockshape[] = {3, 4, 3};
     bool enforceframe = false;
     char *filename = NULL;
 
     caterva_storage_backend_t backend2 = CATERVA_STORAGE_BLOSC;
     int64_t chunkshape2[] = {21, 1, 12};
+    int64_t blockshape2[] = {8, 1, 5};
     bool enforceframe2 = false;
     char *filename2 = NULL;
 
-    test_squeeze(data->ctx, itemsize, ndim, shape, backend, chunkshape, enforceframe, filename,
-        backend2, chunkshape2, enforceframe2, filename2, start, stop);
+    test_squeeze(data->ctx, itemsize, ndim, shape, backend, chunkshape, blockshape, enforceframe, filename,
+        backend2, chunkshape2, blockshape2, enforceframe2, filename2, start, stop);
 }
 
 
@@ -129,16 +133,18 @@ LWTEST_FIXTURE(squeeze, 5_double_plainbuffer_plainbuffer) {
 
     caterva_storage_backend_t backend = CATERVA_STORAGE_PLAINBUFFER;
     int64_t chunkshape[] = {0};
+    int64_t blockshape[] = {0};
     bool enforceframe = false;
     char *filename = NULL;
 
     caterva_storage_backend_t backend2 = CATERVA_STORAGE_PLAINBUFFER;
     int64_t chunkshape2[] = {0};
+    int64_t blockshape2[] = {0};
     bool enforceframe2 = false;
     char *filename2 = NULL;
 
-    test_squeeze(data->ctx, itemsize, ndim, shape, backend, chunkshape, enforceframe, filename,
-                 backend2, chunkshape2, enforceframe2, filename2, start, stop);
+    test_squeeze(data->ctx, itemsize, ndim, shape, backend, chunkshape, blockshape, enforceframe, filename,
+                 backend2, chunkshape2, blockshape2, enforceframe2, filename2, start, stop);
 }
 
 LWTEST_FIXTURE(squeeze, 7_float_blosc_frame_plainbuffer) {
@@ -151,14 +157,16 @@ LWTEST_FIXTURE(squeeze, 7_float_blosc_frame_plainbuffer) {
 
     caterva_storage_backend_t backend = CATERVA_STORAGE_BLOSC;
     int64_t chunkshape[] = {2, 3, 5, 2, 4, 3, 2};
+    int64_t blockshape[] = {1, 2, 3, 2, 3, 2, 1};
     bool enforceframe = true;
     char *filename = NULL;
 
     caterva_storage_backend_t backend2 = CATERVA_STORAGE_PLAINBUFFER;
     int64_t chunkshape2[] = {0};
+    int64_t blockshape2[] = {0};
     bool enforceframe2 = false;
     char *filename2 = NULL;
 
-    test_squeeze(data->ctx, itemsize, ndim, shape, backend, chunkshape, enforceframe, filename,
-                 backend2, chunkshape2, enforceframe2, filename2, start, stop);
+    test_squeeze(data->ctx, itemsize, ndim, shape, backend, chunkshape, blockshape, enforceframe, filename,
+                 backend2, chunkshape2, blockshape2, enforceframe2, filename2, start, stop);
 }

--- a/tests/test_squeeze.c
+++ b/tests/test_squeeze.c
@@ -98,11 +98,12 @@ LWTEST_TEARDOWN(squeeze) {
     caterva_context_free(&data->ctx);
 }
 
-LWTEST_FIXTURE(squeeze, 2_double_blosc_plainbuffer) {
+
+LWTEST_FIXTURE(squeeze, 2_float_blosc_plainbuffer) {
     int64_t start[] = {5, 20};
     int64_t stop[] = {23, 21};
 
-    uint8_t itemsize = sizeof(double );
+    uint8_t itemsize = sizeof(float);
     uint8_t ndim = 2;
     int64_t shape[] = {100, 100};
 
@@ -146,11 +147,11 @@ LWTEST_FIXTURE(squeeze, 3_float_blosc_blosc) {
         backend2, chunkshape2, blockshape2, enforceframe2, filename2, start, stop);
 }
 
-LWTEST_FIXTURE(squeeze, 4_float_plainbuffer_blosc) {
+LWTEST_FIXTURE(squeeze, 4_double_plainbuffer_blosc) {
     int64_t start[] = {5, 20, 10, 60};
     int64_t stop[] = {23, 21, 33, 99};
 
-    uint8_t itemsize = sizeof(float);
+    uint8_t itemsize = sizeof(double);
     uint8_t ndim = 4;
     int64_t shape[] = {100, 100, 100, 100};
 
@@ -171,11 +172,11 @@ LWTEST_FIXTURE(squeeze, 4_float_plainbuffer_blosc) {
 }
 
 
-LWTEST_FIXTURE(squeeze, 5_double_plainbuffer_plainbuffer) {
+LWTEST_FIXTURE(squeeze, 5_uint8_plainbuffer_plainbuffer) {
     int64_t start[] = {1, 12, 3, 12, 6};
     int64_t stop[] = {16, 21, 19, 13, 21};
 
-    uint8_t itemsize = sizeof(double);
+    uint8_t itemsize = sizeof(uint8_t);
     uint8_t ndim = 5;
     int64_t shape[] = {22, 25, 31, 19, 31};
 
@@ -219,17 +220,41 @@ LWTEST_FIXTURE(squeeze, 6_float_blosc_plainbuffer_frame) {
                  backend2, chunkshape2, blockshape2, enforceframe2, filename2, start, stop);
 }
 
-LWTEST_FIXTURE(squeeze, 7_float_blosc_frame_plainbuffer) {
+LWTEST_FIXTURE(squeeze, 7_uint8_blosc_frame_plainbuffer) {
     int64_t start[] = {5, 3, 3, 2, 1, 0, 4};
     int64_t stop[] = {6, 8, 10, 5, 2, 1, 9};
 
-    uint8_t itemsize = sizeof(float);
+    uint8_t itemsize = sizeof(uint8_t);
     uint8_t ndim = 7;
     int64_t shape[] = {6, 8, 12, 6, 7, 6, 9};
 
     caterva_storage_backend_t backend = CATERVA_STORAGE_BLOSC;
     int64_t chunkshape[] = {2, 3, 5, 2, 4, 3, 2};
     int64_t blockshape[] = {1, 2, 3, 2, 3, 2, 1};
+    bool enforceframe = true;
+    char *filename = NULL;
+
+    caterva_storage_backend_t backend2 = CATERVA_STORAGE_PLAINBUFFER;
+    int64_t chunkshape2[] = {0};
+    int64_t blockshape2[] = {0};
+    bool enforceframe2 = false;
+    char *filename2 = NULL;
+
+    test_squeeze(data->ctx, itemsize, ndim, shape, backend, chunkshape, blockshape, enforceframe, filename,
+                 backend2, chunkshape2, blockshape2, enforceframe2, filename2, start, stop);
+}
+
+LWTEST_FIXTURE(squeeze, 8_uint16_blosc_frame_plainbuffer) {
+    int64_t start[] = {5, 4, 3, 1, 2, 1, 0, 3};
+    int64_t stop[] = {6, 8, 7, 4, 7, 2, 1, 9};
+
+    uint8_t itemsize = sizeof(uint16_t);
+    uint8_t ndim = 8;
+    int64_t shape[] = {6, 8, 12, 6, 7, 2, 3, 9};
+
+    caterva_storage_backend_t backend = CATERVA_STORAGE_BLOSC;
+    int64_t chunkshape[] = {2, 3, 7, 2, 4, 1, 3, 2};
+    int64_t blockshape[] = {1, 2, 4, 2, 2, 1, 1, 1};
     bool enforceframe = true;
     char *filename = NULL;
 

--- a/tests/test_to_buffer.c
+++ b/tests/test_to_buffer.c
@@ -44,7 +44,6 @@ static void test_to_buffer(caterva_context_t *ctx, int8_t ndim, int8_t itemsize,
     for (int i = 0; i < ndim; ++i) {
         buffersize *= shape[i];
     }
-    printf("\n bufdest size %ld \n", (buffersize/itemsize));
     /* Create caterva_array_t with original data */
     caterva_array_t *src;
     CATERVA_TEST_ERROR(caterva_array_from_buffer(ctx, result, buffersize, &params, &storage, &src));
@@ -55,10 +54,10 @@ static void test_to_buffer(caterva_context_t *ctx, int8_t ndim, int8_t itemsize,
     /* Fill dest buffer with a slice*/
     CATERVA_TEST_ERROR(caterva_array_to_buffer(ctx, src, destbuffer, buffersize));
 
-    printf("\n to buffer \n");
+    /*printf("\n to buffer \n");
     for (int i=0; i<(buffersize/itemsize); i++) {
         printf("%f, ", ((double*) destbuffer)[i]);
-    }
+    }*/
     /* Assert results */
     assert_buf(destbuffer, result, itemsize, buffersize/itemsize, 1e-14);
 
@@ -128,7 +127,7 @@ LWTEST_FIXTURE(to_buffer, ndim_2_2) {
     free(result);
  }
 */
-/*
+
 LWTEST_FIXTURE(to_buffer, ndim_3_no_sp) {
     const int8_t ndim = 3;
     uint8_t itemsize = sizeof(double);
@@ -151,7 +150,7 @@ LWTEST_FIXTURE(to_buffer, ndim_3_no_sp) {
     test_to_buffer(data->ctx, ndim, itemsize, shape_, backend, pshape_, spshape_, enforceframe, filename, result);
     free(result);
  }
-*/
+
 LWTEST_FIXTURE(to_buffer, ndim_3) {
     const int8_t ndim = 3;
     uint8_t itemsize = sizeof(double);
@@ -175,7 +174,7 @@ LWTEST_FIXTURE(to_buffer, ndim_3) {
     test_to_buffer(data->ctx, ndim, itemsize, shape_, backend, pshape_, spshape_, enforceframe, filename, result);
     free(result);
 }
-/*
+
 LWTEST_FIXTURE(to_buffer, ndim_5_no_sp) {
     const int8_t ndim = 5;
     uint8_t itemsize = sizeof(double);
@@ -243,7 +242,7 @@ LWTEST_FIXTURE(to_buffer, ndim_7) {
     printf("bufsize %ld", buf_size);
     test_to_buffer(data->ctx, ndim, itemsize, shape_, backend, pshape_, spshape_, enforceframe, filename, result);
     free(result);
-}*/
+}
 /*
 LWTEST_FIXTURE(to_buffer, ndim_3_hard) {
     const int8_t ndim = 3;
@@ -268,4 +267,4 @@ LWTEST_FIXTURE(to_buffer, ndim_3_hard) {
     test_to_buffer(data->ctx, ndim, itemsize, shape_, backend, pshape_, spshape_, enforceframe, filename, result);
     free(result);
  }
- */
+*/

--- a/tests/test_to_buffer.c
+++ b/tests/test_to_buffer.c
@@ -44,7 +44,7 @@ static void test_to_buffer(caterva_context_t *ctx, int8_t ndim, int8_t itemsize,
     for (int i = 0; i < ndim; ++i) {
         buffersize *= shape[i];
     }
-
+    printf("\n bufdest size %ld \n", (buffersize/itemsize));
     /* Create caterva_array_t with original data */
     caterva_array_t *src;
     CATERVA_TEST_ERROR(caterva_array_from_buffer(ctx, result, buffersize, &params, &storage, &src));
@@ -55,6 +55,10 @@ static void test_to_buffer(caterva_context_t *ctx, int8_t ndim, int8_t itemsize,
     /* Fill dest buffer with a slice*/
     CATERVA_TEST_ERROR(caterva_array_to_buffer(ctx, src, destbuffer, buffersize));
 
+    printf("\n to buffer \n");
+    for (int i=0; i<(buffersize/itemsize); i++) {
+        printf("%f, ", ((double*) destbuffer)[i]);
+    }
     /* Assert results */
     assert_buf(destbuffer, result, itemsize, buffersize/itemsize, 1e-14);
 
@@ -98,6 +102,7 @@ LWTEST_FIXTURE(to_buffer, ndim_2) {
     }
 
     test_to_buffer(data->ctx, ndim, itemsize, shape_, backend, pshape_, spshape_,  enforceframe, filename, result);
+    free(result);
 }
 
 LWTEST_FIXTURE(to_buffer, ndim_2_2) {
@@ -120,7 +125,8 @@ LWTEST_FIXTURE(to_buffer, ndim_2_2) {
     }
 
     test_to_buffer(data->ctx, ndim, itemsize, shape_, backend, pshape_, spshape_, enforceframe, filename, result);
-}
+    free(result);
+ }
 */
 /*
 LWTEST_FIXTURE(to_buffer, ndim_3_no_sp) {
@@ -143,8 +149,9 @@ LWTEST_FIXTURE(to_buffer, ndim_3_no_sp) {
     }
 
     test_to_buffer(data->ctx, ndim, itemsize, shape_, backend, pshape_, spshape_, enforceframe, filename, result);
-}
-
+    free(result);
+ }
+*/
 LWTEST_FIXTURE(to_buffer, ndim_3) {
     const int8_t ndim = 3;
     uint8_t itemsize = sizeof(double);
@@ -153,7 +160,7 @@ LWTEST_FIXTURE(to_buffer, ndim_3) {
     char *filename = NULL;
 
     int64_t shape_[] = {5, 6, 3};
-    int64_t pshape_[] = {3, 3, 3};
+    int64_t pshape_[] = {4, 3, 3};
     int64_t spshape_[] = {3, 3, 2};
 
     int64_t buf_size = 1;
@@ -166,8 +173,9 @@ LWTEST_FIXTURE(to_buffer, ndim_3) {
     }
 
     test_to_buffer(data->ctx, ndim, itemsize, shape_, backend, pshape_, spshape_, enforceframe, filename, result);
+    free(result);
 }
-
+/*
 LWTEST_FIXTURE(to_buffer, ndim_5_no_sp) {
     const int8_t ndim = 5;
     uint8_t itemsize = sizeof(double);
@@ -188,6 +196,7 @@ LWTEST_FIXTURE(to_buffer, ndim_5_no_sp) {
     }
 
     test_to_buffer(data->ctx, ndim, itemsize, shape_, backend, pshape_, spshape_, enforceframe, filename, result);
+    free(result);
 }
 
 LWTEST_FIXTURE(to_buffer, ndim_6) {
@@ -210,8 +219,9 @@ LWTEST_FIXTURE(to_buffer, ndim_6) {
     }
 
     test_to_buffer(data->ctx, ndim, itemsize, shape_, backend, pshape_, spshape_,  enforceframe, filename, result);
-}
-*/
+    free(result);
+ }
+
 LWTEST_FIXTURE(to_buffer, ndim_7) {
     const int8_t ndim = 7;
     uint8_t itemsize = sizeof(double);
@@ -230,10 +240,10 @@ LWTEST_FIXTURE(to_buffer, ndim_7) {
     for (int64_t i = 0; i < buf_size; ++i) {
         result[i] = (double) i;
     }
-
+    printf("bufsize %ld", buf_size);
     test_to_buffer(data->ctx, ndim, itemsize, shape_, backend, pshape_, spshape_, enforceframe, filename, result);
     free(result);
-}
+}*/
 /*
 LWTEST_FIXTURE(to_buffer, ndim_3_hard) {
     const int8_t ndim = 3;
@@ -256,5 +266,6 @@ LWTEST_FIXTURE(to_buffer, ndim_3_hard) {
     }
 
     test_to_buffer(data->ctx, ndim, itemsize, shape_, backend, pshape_, spshape_, enforceframe, filename, result);
-}
+    free(result);
+ }
  */

--- a/tests/test_to_buffer.c
+++ b/tests/test_to_buffer.c
@@ -75,15 +75,15 @@ LWTEST_TEARDOWN(to_buffer) {
     caterva_context_free(&data->ctx);
 }
 
-/*
-LWTEST_FIXTURE(to_buffer, ndim_2) {
+
+LWTEST_FIXTURE(to_buffer, ndim_2_plain_float) {
     const int8_t ndim = 2;
     int64_t shape_[] = {10, 10};
-    int64_t pshape_[] = {2, 3};
-    int64_t spshape_[] = {1, 2};
+    int64_t pshape_[] = {0};
+    int64_t spshape_[] = {0};
 
-    uint8_t itemsize = sizeof(double);
-    caterva_storage_backend_t backend = CATERVA_STORAGE_BLOSC;
+    uint8_t itemsize = sizeof(float);
+    caterva_storage_backend_t backend = CATERVA_STORAGE_PLAINBUFFER;
     bool enforceframe = false;
     char *filename = NULL;
 
@@ -91,25 +91,25 @@ LWTEST_FIXTURE(to_buffer, ndim_2) {
     for (int i = 0; i < ndim; ++i) {
         buf_size *= (shape_[i]);
     }
-    double *result = (double *) data->ctx->cfg->alloc((size_t)buf_size * itemsize);
+    float *result = (float *) data->ctx->cfg->alloc((size_t)buf_size * itemsize);
     for (int64_t i = 0; i < buf_size; ++i) {
-        result[i] = (double) i;
+        result[i] = (float) i;
     }
 
     test_to_buffer(data->ctx, ndim, itemsize, shape_, backend, pshape_, spshape_,  enforceframe, filename, result);
     data->ctx->cfg->free(result);
 }
 
-LWTEST_FIXTURE(to_buffer, ndim_2_2) {
+LWTEST_FIXTURE(to_buffer, ndim_2_blosc) {
     const int8_t ndim = 2;
     uint8_t itemsize = sizeof(double);
     caterva_storage_backend_t backend = CATERVA_STORAGE_BLOSC;
     bool enforceframe = false;
     char *filename = NULL;
 
-    int64_t shape_[] = {5, 6};
-    int64_t pshape_[] = {3, 3};
-    int64_t spshape_[] = {2, 2};
+    int64_t shape_[] = {7, 10};
+    int64_t pshape_[] = {5, 6};
+    int64_t spshape_[] = {4, 5};
     int64_t buf_size = 1;
     for (int i = 0; i < ndim; ++i) {
         buf_size *= (shape_[i]);
@@ -122,32 +122,32 @@ LWTEST_FIXTURE(to_buffer, ndim_2_2) {
     test_to_buffer(data->ctx, ndim, itemsize, shape_, backend, pshape_, spshape_, enforceframe, filename, result);
     data->ctx->cfg->free(result);
  }
-*/
 
-LWTEST_FIXTURE(to_buffer, ndim_3_no_sp) {
+
+LWTEST_FIXTURE(to_buffer, ndim_3_float) {
     const int8_t ndim = 3;
-    uint8_t itemsize = sizeof(double);
+    uint8_t itemsize = sizeof(float);
     caterva_storage_backend_t backend = CATERVA_STORAGE_BLOSC;
     bool enforceframe = false;
     char *filename = NULL;
 
     int64_t shape_[] = {10, 10, 10};
-    int64_t pshape_[] = {3, 5, 2};
-    int64_t spshape_[] = {3, 3, 2};
+    int64_t pshape_[] = {7, 5, 4};
+    int64_t spshape_[] = {4, 4, 3};
     int64_t buf_size = 1;
     for (int i = 0; i < ndim; ++i) {
         buf_size *= (shape_[i]);
     }
-    double *result = (double *) data->ctx->cfg->alloc((size_t)buf_size * itemsize);
+    float *result = (float *) data->ctx->cfg->alloc((size_t)buf_size * itemsize);
     for (int64_t i = 0; i < buf_size; ++i) {
-        result[i] = (double) i;
+        result[i] = (float) i;
     }
 
     test_to_buffer(data->ctx, ndim, itemsize, shape_, backend, pshape_, spshape_, enforceframe, filename, result);
     data->ctx->cfg->free(result);
  }
 
-LWTEST_FIXTURE(to_buffer, ndim_3) {
+LWTEST_FIXTURE(to_buffer, ndim_3_double) {
     const int8_t ndim = 3;
     uint8_t itemsize = sizeof(double);
     caterva_storage_backend_t backend = CATERVA_STORAGE_BLOSC;
@@ -171,9 +171,32 @@ LWTEST_FIXTURE(to_buffer, ndim_3) {
     data->ctx->cfg->free(result);
 }
 
-LWTEST_FIXTURE(to_buffer, ndim_5_no_sp) {
+LWTEST_FIXTURE(to_buffer, ndim_4_plain) {
+    const int8_t ndim = 4;
+    uint8_t itemsize = sizeof(double );
+    caterva_storage_backend_t backend = CATERVA_STORAGE_PLAINBUFFER;
+    bool enforceframe = false;
+    char *filename = NULL;
+
+    int64_t shape_[] = {10, 10, 10, 10};
+    int64_t pshape_[] = {0};
+    int64_t spshape_[] = {0};
+    int64_t buf_size = 1;
+    for (int i = 0; i < ndim; ++i) {
+        buf_size *= (shape_[i]);
+    }
+    double *result = (double *) data->ctx->cfg->alloc((size_t)buf_size * itemsize);
+    for (int64_t i = 0; i < buf_size; ++i) {
+        result[i] = (double ) i;
+    }
+
+    test_to_buffer(data->ctx, ndim, itemsize, shape_, backend, pshape_, spshape_, enforceframe, filename, result);
+    data->ctx->cfg->free(result);
+}
+
+LWTEST_FIXTURE(to_buffer, ndim_5_float) {
     const int8_t ndim = 5;
-    uint8_t itemsize = sizeof(double);
+    uint8_t itemsize = sizeof(float);
     caterva_storage_backend_t backend = CATERVA_STORAGE_BLOSC;
     bool enforceframe = false;
     char *filename = NULL;
@@ -185,9 +208,9 @@ LWTEST_FIXTURE(to_buffer, ndim_5_no_sp) {
     for (int i = 0; i < ndim; ++i) {
         buf_size *= (shape_[i]);
     }
-    double *result = (double *) data->ctx->cfg->alloc((size_t)buf_size * itemsize);
+    float *result = (float *) data->ctx->cfg->alloc((size_t)buf_size * itemsize);
     for (int64_t i = 0; i < buf_size; ++i) {
-        result[i] = (double) i;
+        result[i] = (float) i;
     }
 
     test_to_buffer(data->ctx, ndim, itemsize, shape_, backend, pshape_, spshape_, enforceframe, filename, result);
@@ -217,9 +240,9 @@ LWTEST_FIXTURE(to_buffer, ndim_6) {
     data->ctx->cfg->free(result);
  }
 
-LWTEST_FIXTURE(to_buffer, ndim_7) {
+LWTEST_FIXTURE(to_buffer, ndim_7_float) {
     const int8_t ndim = 7;
-    uint8_t itemsize = sizeof(double);
+    uint8_t itemsize = sizeof(float);
     caterva_storage_backend_t backend = CATERVA_STORAGE_BLOSC;
     bool enforceframe = false;
     char *filename = NULL;
@@ -231,9 +254,31 @@ LWTEST_FIXTURE(to_buffer, ndim_7) {
     for (int i = 0; i < ndim; ++i) {
         buf_size *= (shape_[i]);
     }
-    double *result = (double *) data->ctx->cfg->alloc((size_t)buf_size * itemsize);
+    float *result = (float *) data->ctx->cfg->alloc((size_t)buf_size * itemsize);
     for (int64_t i = 0; i < buf_size; ++i) {
-        result[i] = (double) i;
+        result[i] = (float) i;
+    }
+    test_to_buffer(data->ctx, ndim, itemsize, shape_, backend, pshape_, spshape_, enforceframe, filename, result);
+    data->ctx->cfg->free(result);
+}
+
+LWTEST_FIXTURE(to_buffer, ndim_8_plain) {
+    const int8_t ndim = 8;
+    uint8_t itemsize = sizeof(float);
+    caterva_storage_backend_t backend = CATERVA_STORAGE_PLAINBUFFER;
+    bool enforceframe = false;
+    char *filename = NULL;
+
+    int64_t shape_[] = {4, 5, 3, 4, 4, 5, 2, 8};
+    int64_t pshape_[] = {0};
+    int64_t spshape_[] = {0};
+    int64_t buf_size = 1;
+    for (int i = 0; i < ndim; ++i) {
+        buf_size *= (shape_[i]);
+    }
+    float *result = (float *) data->ctx->cfg->alloc((size_t)buf_size * itemsize);
+    for (int64_t i = 0; i < buf_size; ++i) {
+        result[i] = (float) i;
     }
     test_to_buffer(data->ctx, ndim, itemsize, shape_, backend, pshape_, spshape_, enforceframe, filename, result);
     data->ctx->cfg->free(result);

--- a/tests/test_to_buffer.c
+++ b/tests/test_to_buffer.c
@@ -22,7 +22,7 @@ static void test_to_buffer(caterva_context_t *ctx, int8_t ndim, int8_t itemsize,
         params.shape[i] = shape[i];
     }
 
-    caterva_storage_t storage;
+    caterva_storage_t storage = {0};
     storage.backend = backend;
     switch (backend) {
         case CATERVA_STORAGE_PLAINBUFFER:
@@ -44,12 +44,7 @@ static void test_to_buffer(caterva_context_t *ctx, int8_t ndim, int8_t itemsize,
     for (int i = 0; i < ndim; ++i) {
         buffersize *= shape[i];
     }
-/*
-    printf("\n buffer: \n");
-    for (int i=0; i < (buffersize/itemsize); i++) {
-        printf("%f, ", ((double *) result)[i]);
-    }
-*/
+
     /* Create caterva_array_t with original data */
     caterva_array_t *src;
     CATERVA_TEST_ERROR(caterva_array_from_buffer(ctx, result, buffersize, &params, &storage, &src));
@@ -59,12 +54,7 @@ static void test_to_buffer(caterva_context_t *ctx, int8_t ndim, int8_t itemsize,
 
     /* Fill dest buffer with a slice*/
     CATERVA_TEST_ERROR(caterva_array_to_buffer(ctx, src, destbuffer, buffersize));
-/*
-    printf("\n to buffer: \n");
-    for (int i=0; i < (buffersize/itemsize); i++) {
-        printf("%f, ", ((double *) destbuffer)[i]);
-    }
-  */
+
     /* Assert results */
     assert_buf(destbuffer, result, itemsize, buffersize/itemsize, 1e-14);
 

--- a/tests/test_to_buffer.c
+++ b/tests/test_to_buffer.c
@@ -76,6 +76,30 @@ LWTEST_TEARDOWN(to_buffer) {
 }
 
 
+LWTEST_FIXTURE(to_buffer, ndim_1) {
+    const int8_t ndim = 1;
+    int64_t shape_[] = {30};
+    int64_t pshape_[] = {30};
+    int64_t spshape_[] = {30};
+
+    uint8_t itemsize = sizeof(double);
+    caterva_storage_backend_t backend = CATERVA_STORAGE_BLOSC;
+    bool enforceframe = false;
+    char *filename = NULL;
+
+    int64_t buf_size = 1;
+    for (int i = 0; i < ndim; ++i) {
+        buf_size *= (shape_[i]);
+    }
+    float *result = (float *) data->ctx->cfg->alloc((size_t)buf_size * itemsize);
+    for (int64_t i = 0; i < buf_size; ++i) {
+        result[i] = (float) i;
+    }
+
+    test_to_buffer(data->ctx, ndim, itemsize, shape_, backend, pshape_, spshape_,  enforceframe, filename, result);
+    data->ctx->cfg->free(result);
+}
+
 LWTEST_FIXTURE(to_buffer, ndim_2_plain_float) {
     const int8_t ndim = 2;
     int64_t shape_[] = {10, 10};

--- a/tests/test_to_buffer.c
+++ b/tests/test_to_buffer.c
@@ -1,0 +1,270 @@
+/*
+ * Copyright (C) 2018 Francesc Alted, Aleix Alcacer.
+ * Copyright (C) 2019-present Blosc Development team <blosc@blosc.org>
+ * All rights reserved.
+ *
+ * This source code is licensed under both the BSD-style license (found in the
+ * LICENSE file in the root directory of this source tree) and the GPLv2 (found
+ * in the COPYING file in the root directory of this source tree).
+ * You may select, at your option, one of the above-listed licenses.
+ */
+
+#include "test_common.h"
+
+static void test_to_buffer(caterva_context_t *ctx, int8_t ndim, int8_t itemsize, int64_t *shape,
+                           caterva_storage_backend_t backend, int64_t *chunkshape, int64_t *blockshape, bool enforceframe,
+                           char* filename, void *result) {
+
+    caterva_params_t params;
+    params.itemsize = itemsize;
+    params.ndim = ndim;
+    for (int i = 0; i < ndim; ++i) {
+        params.shape[i] = shape[i];
+    }
+
+    caterva_storage_t storage;
+    storage.backend = backend;
+    switch (backend) {
+        case CATERVA_STORAGE_PLAINBUFFER:
+            break;
+        case CATERVA_STORAGE_BLOSC:
+            storage.properties.blosc.filename = filename;
+            storage.properties.blosc.enforceframe = enforceframe;
+            for (int i = 0; i < ndim; ++i) {
+                storage.properties.blosc.chunkshape[i] = chunkshape[i];
+                storage.properties.blosc.blockshape[i] = blockshape[i];
+            }
+            break;
+        default:
+            CATERVA_TEST_ERROR(CATERVA_ERR_INVALID_STORAGE);
+    }
+
+    /* Create original data */
+    int64_t buffersize = itemsize;
+    for (int i = 0; i < ndim; ++i) {
+        buffersize *= shape[i];
+    }
+/*
+    printf("\n buffer: \n");
+    for (int i=0; i < (buffersize/itemsize); i++) {
+        printf("%f, ", ((double *) result)[i]);
+    }
+*/
+    /* Create caterva_array_t with original data */
+    caterva_array_t *src;
+    CATERVA_TEST_ERROR(caterva_array_from_buffer(ctx, result, buffersize, &params, &storage, &src));
+
+    /* Create dest buffer */
+    uint8_t *destbuffer = malloc(buffersize);
+
+    /* Fill dest buffer with a slice*/
+    CATERVA_TEST_ERROR(caterva_array_to_buffer(ctx, src, destbuffer, buffersize));
+/*
+    printf("\n to buffer: \n");
+    for (int i=0; i < (buffersize/itemsize); i++) {
+        printf("%f, ", ((double *) destbuffer)[i]);
+    }
+  */
+    /* Assert results */
+    assert_buf(destbuffer, result, itemsize, buffersize/itemsize, 1e-14);
+
+    free(destbuffer);
+    CATERVA_TEST_ERROR(caterva_array_free(ctx, &src));
+}
+
+
+LWTEST_DATA(to_buffer) {
+    caterva_context_t *ctx;
+};
+
+LWTEST_SETUP(to_buffer) {
+    caterva_config_t cfg = CATERVA_CONFIG_DEFAULTS;
+    caterva_context_new(&cfg, &data->ctx);
+}
+
+LWTEST_TEARDOWN(to_buffer) {
+    caterva_context_free(&data->ctx);
+}
+
+/*
+LWTEST_FIXTURE(to_buffer, ndim_2) {
+    const int8_t ndim = 2;
+    int64_t shape_[] = {10, 10};
+    int64_t pshape_[] = {2, 3};
+    int64_t spshape_[] = {1, 2};
+
+    uint8_t itemsize = sizeof(double);
+    caterva_storage_backend_t backend = CATERVA_STORAGE_BLOSC;
+    bool enforceframe = false;
+    char *filename = NULL;
+
+    int64_t buf_size = 1;
+    for (int i = 0; i < ndim; ++i) {
+        buf_size *= (shape_[i]);
+    }
+    double *result = (double *) malloc((size_t)buf_size * itemsize);
+    for (int64_t i = 0; i < buf_size; ++i) {
+        result[i] = (double) i;
+    }
+
+    test_to_buffer(data->ctx, ndim, itemsize, shape_, backend, pshape_, spshape_,  enforceframe, filename, result);
+}
+
+LWTEST_FIXTURE(to_buffer, ndim_2_2) {
+    const int8_t ndim = 2;
+    uint8_t itemsize = sizeof(double);
+    caterva_storage_backend_t backend = CATERVA_STORAGE_BLOSC;
+    bool enforceframe = false;
+    char *filename = NULL;
+
+    int64_t shape_[] = {5, 6};
+    int64_t pshape_[] = {3, 3};
+    int64_t spshape_[] = {2, 2};
+    int64_t buf_size = 1;
+    for (int i = 0; i < ndim; ++i) {
+        buf_size *= (shape_[i]);
+    }
+    double *result = (double *) malloc((size_t)buf_size *itemsize);
+    for (int64_t i = 0; i < buf_size; ++i) {
+        result[i] = (double) i;
+    }
+
+    test_to_buffer(data->ctx, ndim, itemsize, shape_, backend, pshape_, spshape_, enforceframe, filename, result);
+}
+*/
+/*
+LWTEST_FIXTURE(to_buffer, ndim_3_no_sp) {
+    const int8_t ndim = 3;
+    uint8_t itemsize = sizeof(double);
+    caterva_storage_backend_t backend = CATERVA_STORAGE_BLOSC;
+    bool enforceframe = false;
+    char *filename = NULL;
+
+    int64_t shape_[] = {10, 10, 10};
+    int64_t pshape_[] = {3, 5, 2};
+    int64_t spshape_[] = {3, 3, 2};
+    int64_t buf_size = 1;
+    for (int i = 0; i < ndim; ++i) {
+        buf_size *= (shape_[i]);
+    }
+    double *result = (double *) malloc((size_t)buf_size * itemsize);
+    for (int64_t i = 0; i < buf_size; ++i) {
+        result[i] = (double) i;
+    }
+
+    test_to_buffer(data->ctx, ndim, itemsize, shape_, backend, pshape_, spshape_, enforceframe, filename, result);
+}
+
+LWTEST_FIXTURE(to_buffer, ndim_3) {
+    const int8_t ndim = 3;
+    uint8_t itemsize = sizeof(double);
+    caterva_storage_backend_t backend = CATERVA_STORAGE_BLOSC;
+    bool enforceframe = false;
+    char *filename = NULL;
+
+    int64_t shape_[] = {5, 6, 3};
+    int64_t pshape_[] = {3, 3, 3};
+    int64_t spshape_[] = {3, 3, 2};
+
+    int64_t buf_size = 1;
+    for (int i = 0; i < ndim; ++i) {
+        buf_size *= (shape_[i]);
+    }
+    double *result = (double *) malloc((size_t)buf_size * itemsize);
+    for (int64_t i = 0; i < buf_size; ++i) {
+        result[i] = (double) i;
+    }
+
+    test_to_buffer(data->ctx, ndim, itemsize, shape_, backend, pshape_, spshape_, enforceframe, filename, result);
+}
+
+LWTEST_FIXTURE(to_buffer, ndim_5_no_sp) {
+    const int8_t ndim = 5;
+    uint8_t itemsize = sizeof(double);
+    caterva_storage_backend_t backend = CATERVA_STORAGE_BLOSC;
+    bool enforceframe = false;
+    char *filename = NULL;
+
+    int64_t shape_[] = {10, 10, 10, 10, 10};
+    int64_t pshape_[] = {3, 5, 2, 4, 5};
+    int64_t spshape_[] = {3, 3, 2, 3, 5};
+    int64_t buf_size = 1;
+    for (int i = 0; i < ndim; ++i) {
+        buf_size *= (shape_[i]);
+    }
+    double *result = (double *) malloc((size_t)buf_size * itemsize);
+    for (int64_t i = 0; i < buf_size; ++i) {
+        result[i] = (double) i;
+    }
+
+    test_to_buffer(data->ctx, ndim, itemsize, shape_, backend, pshape_, spshape_, enforceframe, filename, result);
+}
+
+LWTEST_FIXTURE(to_buffer, ndim_6) {
+    const int8_t ndim = 6;
+    uint8_t itemsize = sizeof(double);
+    caterva_storage_backend_t backend = CATERVA_STORAGE_BLOSC;
+    bool enforceframe = false;
+    char *filename = NULL;
+
+    int64_t shape_[] = {10, 10, 10, 10, 10, 10};
+    int64_t pshape_[] = {3, 4, 2, 2, 2, 3};
+    int64_t spshape_[] = {2, 3, 1, 2, 1, 2};
+    int64_t buf_size = 1;
+    for (int i = 0; i < ndim; ++i) {
+        buf_size *= (shape_[i]);
+    }
+    double *result = (double *) malloc((size_t)buf_size * itemsize);
+    for (int64_t i = 0; i < buf_size; ++i) {
+        result[i] = (double) i;
+    }
+
+    test_to_buffer(data->ctx, ndim, itemsize, shape_, backend, pshape_, spshape_,  enforceframe, filename, result);
+}
+*/
+LWTEST_FIXTURE(to_buffer, ndim_7) {
+    const int8_t ndim = 7;
+    uint8_t itemsize = sizeof(double);
+    caterva_storage_backend_t backend = CATERVA_STORAGE_BLOSC;
+    bool enforceframe = false;
+    char *filename = NULL;
+
+    int64_t shape_[] = {4, 5, 3, 4, 4, 5, 2};
+    int64_t pshape_[] = {3, 4, 2, 2, 2, 3, 1};
+    int64_t spshape_[] = {2, 3, 2, 2, 2, 3, 1};
+    int64_t buf_size = 1;
+    for (int i = 0; i < ndim; ++i) {
+        buf_size *= (shape_[i]);
+    }
+    double *result = (double *) malloc((size_t)buf_size * itemsize);
+    for (int64_t i = 0; i < buf_size; ++i) {
+        result[i] = (double) i;
+    }
+
+    test_to_buffer(data->ctx, ndim, itemsize, shape_, backend, pshape_, spshape_, enforceframe, filename, result);
+    free(result);
+}
+/*
+LWTEST_FIXTURE(to_buffer, ndim_3_hard) {
+    const int8_t ndim = 3;
+    uint8_t itemsize = sizeof(double);
+    caterva_storage_backend_t backend = CATERVA_STORAGE_BLOSC;
+    bool enforceframe = false;
+    char *filename = NULL;
+
+    int64_t shape_[] = {252, 252, 252};
+    int64_t pshape_[] = {64, 64, 64};
+    int64_t spshape_[] = {16, 16, 16};
+
+    int64_t buf_size = 1;
+    for (int i = 0; i < ndim; ++i) {
+        buf_size *= (shape_[i]);
+    }
+    double *result = (double *) malloc((size_t)buf_size * itemsize);
+    for (int64_t i = 0; i < buf_size; ++i) {
+        result[i] = (double) i;
+    }
+
+    test_to_buffer(data->ctx, ndim, itemsize, shape_, backend, pshape_, spshape_, enforceframe, filename, result);
+}
+ */

--- a/tests/test_to_buffer.c
+++ b/tests/test_to_buffer.c
@@ -49,19 +49,15 @@ static void test_to_buffer(caterva_context_t *ctx, int8_t ndim, int8_t itemsize,
     CATERVA_TEST_ERROR(caterva_array_from_buffer(ctx, result, buffersize, &params, &storage, &src));
 
     /* Create dest buffer */
-    uint8_t *destbuffer = malloc(buffersize);
+    uint8_t *destbuffer = ctx->cfg->alloc(buffersize);
 
     /* Fill dest buffer with a slice*/
     CATERVA_TEST_ERROR(caterva_array_to_buffer(ctx, src, destbuffer, buffersize));
 
-    /*printf("\n to buffer \n");
-    for (int i=0; i<(buffersize/itemsize); i++) {
-        printf("%f, ", ((double*) destbuffer)[i]);
-    }*/
     /* Assert results */
     assert_buf(destbuffer, result, itemsize, buffersize/itemsize, 1e-14);
 
-    free(destbuffer);
+    ctx->cfg->free(destbuffer);
     CATERVA_TEST_ERROR(caterva_array_free(ctx, &src));
 }
 
@@ -95,13 +91,13 @@ LWTEST_FIXTURE(to_buffer, ndim_2) {
     for (int i = 0; i < ndim; ++i) {
         buf_size *= (shape_[i]);
     }
-    double *result = (double *) malloc((size_t)buf_size * itemsize);
+    double *result = (double *) data->ctx->cfg->alloc((size_t)buf_size * itemsize);
     for (int64_t i = 0; i < buf_size; ++i) {
         result[i] = (double) i;
     }
 
     test_to_buffer(data->ctx, ndim, itemsize, shape_, backend, pshape_, spshape_,  enforceframe, filename, result);
-    free(result);
+    data->ctx->cfg->free(result);
 }
 
 LWTEST_FIXTURE(to_buffer, ndim_2_2) {
@@ -118,13 +114,13 @@ LWTEST_FIXTURE(to_buffer, ndim_2_2) {
     for (int i = 0; i < ndim; ++i) {
         buf_size *= (shape_[i]);
     }
-    double *result = (double *) malloc((size_t)buf_size *itemsize);
+    double *result = (double *) data->ctx->cfg->alloc((size_t)buf_size *itemsize);
     for (int64_t i = 0; i < buf_size; ++i) {
         result[i] = (double) i;
     }
 
     test_to_buffer(data->ctx, ndim, itemsize, shape_, backend, pshape_, spshape_, enforceframe, filename, result);
-    free(result);
+    data->ctx->cfg->free(result);
  }
 */
 
@@ -142,13 +138,13 @@ LWTEST_FIXTURE(to_buffer, ndim_3_no_sp) {
     for (int i = 0; i < ndim; ++i) {
         buf_size *= (shape_[i]);
     }
-    double *result = (double *) malloc((size_t)buf_size * itemsize);
+    double *result = (double *) data->ctx->cfg->alloc((size_t)buf_size * itemsize);
     for (int64_t i = 0; i < buf_size; ++i) {
         result[i] = (double) i;
     }
 
     test_to_buffer(data->ctx, ndim, itemsize, shape_, backend, pshape_, spshape_, enforceframe, filename, result);
-    free(result);
+    data->ctx->cfg->free(result);
  }
 
 LWTEST_FIXTURE(to_buffer, ndim_3) {
@@ -166,13 +162,13 @@ LWTEST_FIXTURE(to_buffer, ndim_3) {
     for (int i = 0; i < ndim; ++i) {
         buf_size *= (shape_[i]);
     }
-    double *result = (double *) malloc((size_t)buf_size * itemsize);
+    double *result = (double *) data->ctx->cfg->alloc((size_t)buf_size * itemsize);
     for (int64_t i = 0; i < buf_size; ++i) {
         result[i] = (double) i;
     }
 
     test_to_buffer(data->ctx, ndim, itemsize, shape_, backend, pshape_, spshape_, enforceframe, filename, result);
-    free(result);
+    data->ctx->cfg->free(result);
 }
 
 LWTEST_FIXTURE(to_buffer, ndim_5_no_sp) {
@@ -189,13 +185,13 @@ LWTEST_FIXTURE(to_buffer, ndim_5_no_sp) {
     for (int i = 0; i < ndim; ++i) {
         buf_size *= (shape_[i]);
     }
-    double *result = (double *) malloc((size_t)buf_size * itemsize);
+    double *result = (double *) data->ctx->cfg->alloc((size_t)buf_size * itemsize);
     for (int64_t i = 0; i < buf_size; ++i) {
         result[i] = (double) i;
     }
 
     test_to_buffer(data->ctx, ndim, itemsize, shape_, backend, pshape_, spshape_, enforceframe, filename, result);
-    free(result);
+    data->ctx->cfg->free(result);
 }
 
 LWTEST_FIXTURE(to_buffer, ndim_6) {
@@ -212,13 +208,13 @@ LWTEST_FIXTURE(to_buffer, ndim_6) {
     for (int i = 0; i < ndim; ++i) {
         buf_size *= (shape_[i]);
     }
-    double *result = (double *) malloc((size_t)buf_size * itemsize);
+    double *result = (double *) data->ctx->cfg->alloc((size_t)buf_size * itemsize);
     for (int64_t i = 0; i < buf_size; ++i) {
         result[i] = (double) i;
     }
 
     test_to_buffer(data->ctx, ndim, itemsize, shape_, backend, pshape_, spshape_,  enforceframe, filename, result);
-    free(result);
+    data->ctx->cfg->free(result);
  }
 
 LWTEST_FIXTURE(to_buffer, ndim_7) {
@@ -235,13 +231,12 @@ LWTEST_FIXTURE(to_buffer, ndim_7) {
     for (int i = 0; i < ndim; ++i) {
         buf_size *= (shape_[i]);
     }
-    double *result = (double *) malloc((size_t)buf_size * itemsize);
+    double *result = (double *) data->ctx->cfg->alloc((size_t)buf_size * itemsize);
     for (int64_t i = 0; i < buf_size; ++i) {
         result[i] = (double) i;
     }
-    printf("bufsize %ld", buf_size);
     test_to_buffer(data->ctx, ndim, itemsize, shape_, backend, pshape_, spshape_, enforceframe, filename, result);
-    free(result);
+    data->ctx->cfg->free(result);
 }
 /*
 LWTEST_FIXTURE(to_buffer, ndim_3_hard) {
@@ -259,12 +254,12 @@ LWTEST_FIXTURE(to_buffer, ndim_3_hard) {
     for (int i = 0; i < ndim; ++i) {
         buf_size *= (shape_[i]);
     }
-    double *result = (double *) malloc((size_t)buf_size * itemsize);
+    double *result = (double *) data->ctx->cfg->alloc((size_t)buf_size * itemsize);
     for (int64_t i = 0; i < buf_size; ++i) {
         result[i] = (double) i;
     }
 
     test_to_buffer(data->ctx, ndim, itemsize, shape_, backend, pshape_, spshape_, enforceframe, filename, result);
-    free(result);
+    data->ctx->cfg->free(result);
  }
 */

--- a/tests/test_to_buffer.c
+++ b/tests/test_to_buffer.c
@@ -100,13 +100,13 @@ LWTEST_FIXTURE(to_buffer, ndim_1) {
     data->ctx->cfg->free(result);
 }
 
-LWTEST_FIXTURE(to_buffer, ndim_2_plain_float) {
+LWTEST_FIXTURE(to_buffer, ndim_2_plain_uint16) {
     const int8_t ndim = 2;
     int64_t shape_[] = {10, 10};
     int64_t pshape_[] = {0};
     int64_t spshape_[] = {0};
 
-    uint8_t itemsize = sizeof(float);
+    uint8_t itemsize = sizeof(uint16_t);
     caterva_storage_backend_t backend = CATERVA_STORAGE_PLAINBUFFER;
     bool enforceframe = false;
     char *filename = NULL;
@@ -115,9 +115,9 @@ LWTEST_FIXTURE(to_buffer, ndim_2_plain_float) {
     for (int i = 0; i < ndim; ++i) {
         buf_size *= (shape_[i]);
     }
-    float *result = (float *) data->ctx->cfg->alloc((size_t)buf_size * itemsize);
+    uint16_t *result = (uint16_t *) data->ctx->cfg->alloc((size_t)buf_size * itemsize);
     for (int64_t i = 0; i < buf_size; ++i) {
-        result[i] = (float) i;
+        result[i] = (uint16_t) i;
     }
 
     test_to_buffer(data->ctx, ndim, itemsize, shape_, backend, pshape_, spshape_,  enforceframe, filename, result);
@@ -195,9 +195,9 @@ LWTEST_FIXTURE(to_buffer, ndim_3_double) {
     data->ctx->cfg->free(result);
 }
 
-LWTEST_FIXTURE(to_buffer, ndim_4_plain) {
+LWTEST_FIXTURE(to_buffer, ndim_4_plain_uint8) {
     const int8_t ndim = 4;
-    uint8_t itemsize = sizeof(double );
+    uint8_t itemsize = sizeof(uint8_t );
     caterva_storage_backend_t backend = CATERVA_STORAGE_PLAINBUFFER;
     bool enforceframe = false;
     char *filename = NULL;
@@ -209,9 +209,9 @@ LWTEST_FIXTURE(to_buffer, ndim_4_plain) {
     for (int i = 0; i < ndim; ++i) {
         buf_size *= (shape_[i]);
     }
-    double *result = (double *) data->ctx->cfg->alloc((size_t)buf_size * itemsize);
+    uint8_t *result = (uint8_t *) data->ctx->cfg->alloc((size_t)buf_size * itemsize);
     for (int64_t i = 0; i < buf_size; ++i) {
-        result[i] = (double ) i;
+        result[i] = (uint8_t ) i;
     }
 
     test_to_buffer(data->ctx, ndim, itemsize, shape_, backend, pshape_, spshape_, enforceframe, filename, result);
@@ -264,9 +264,9 @@ LWTEST_FIXTURE(to_buffer, ndim_6) {
     data->ctx->cfg->free(result);
  }
 
-LWTEST_FIXTURE(to_buffer, ndim_7_float) {
+LWTEST_FIXTURE(to_buffer, ndim_7_uint16) {
     const int8_t ndim = 7;
-    uint8_t itemsize = sizeof(float);
+    uint8_t itemsize = sizeof(uint16_t);
     caterva_storage_backend_t backend = CATERVA_STORAGE_BLOSC;
     bool enforceframe = false;
     char *filename = NULL;
@@ -278,9 +278,9 @@ LWTEST_FIXTURE(to_buffer, ndim_7_float) {
     for (int i = 0; i < ndim; ++i) {
         buf_size *= (shape_[i]);
     }
-    float *result = (float *) data->ctx->cfg->alloc((size_t)buf_size * itemsize);
+    uint16_t *result = (uint16_t *) data->ctx->cfg->alloc((size_t)buf_size * itemsize);
     for (int64_t i = 0; i < buf_size; ++i) {
-        result[i] = (float) i;
+        result[i] = (uint16_t) i;
     }
     test_to_buffer(data->ctx, ndim, itemsize, shape_, backend, pshape_, spshape_, enforceframe, filename, result);
     data->ctx->cfg->free(result);

--- a/tests/test_to_buffer.c
+++ b/tests/test_to_buffer.c
@@ -286,9 +286,9 @@ LWTEST_FIXTURE(to_buffer, ndim_7_float) {
     data->ctx->cfg->free(result);
 }
 
-LWTEST_FIXTURE(to_buffer, ndim_8_plain) {
+LWTEST_FIXTURE(to_buffer, ndim_8_uint8_plain) {
     const int8_t ndim = 8;
-    uint8_t itemsize = sizeof(float);
+    uint8_t itemsize = sizeof(uint8_t);
     caterva_storage_backend_t backend = CATERVA_STORAGE_PLAINBUFFER;
     bool enforceframe = false;
     char *filename = NULL;
@@ -300,7 +300,7 @@ LWTEST_FIXTURE(to_buffer, ndim_8_plain) {
     for (int i = 0; i < ndim; ++i) {
         buf_size *= (shape_[i]);
     }
-    float *result = (float *) data->ctx->cfg->alloc((size_t)buf_size * itemsize);
+    uint8_t *result = (uint8_t *) data->ctx->cfg->alloc((size_t)buf_size * itemsize);
     for (int64_t i = 0; i < buf_size; ++i) {
         result[i] = (float) i;
     }


### PR DESCRIPTION
Update to a new version of Caterva that takes care of blocks (subpartitions).
test_repart_chunk works correctly, but there are some bugs in test_get_slice_buffer that need to be fixed to evaluate the performance of test_append and itself.