### PR TITLE
fix link to Caterva slides

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,4 +20,4 @@ For more info, check out the
 [Caterva documentation](https://caterva.readthedocs.io).
   
 Here are slides of a gentle
-[introductory talk to Caterva](http://blosc.org/docs/Caterva-HDF5-Workshop.pdf).
+[introductory talk to Caterva](https://www.hdfgroup.org/wp-content/uploads/2019/09/Caterva-HDF5-Workshop_v3.pdf).


### PR DESCRIPTION
got a 404 when I clicked on the link to slides in the README
found this link to a "v3" of what I'm guessing is the same talk.
If not I'm sure you have the correct link, in that case I can just close this PR and let you fix