### PR TITLE
Add shrink capability to resize

### DIFF
--- a/caterva/caterva.h
+++ b/caterva/caterva.h
@@ -635,7 +635,6 @@ int caterva_meta_update(caterva_ctx_t *ctx, caterva_array_t *array,
  *
  * @return An error code
  */
-int caterva_resize(caterva_ctx_t *ctx, caterva_array_t *array,
-                         int64_t *new_shape);
+int caterva_resize(caterva_ctx_t *ctx, caterva_array_t *array, int64_t *new_shape);
 
 #endif  // CATERVA_CATERVA_H_

--- a/caterva/caterva.h
+++ b/caterva/caterva.h
@@ -629,12 +629,13 @@ int caterva_meta_update(caterva_ctx_t *ctx, caterva_array_t *array,
 /**
  * @brief Resize the shape of an array
  *
+ * @param ctx The context to be used.
  * @param array The array to be resized.
  * @param new_shape The new shape from the array.
  *
  * @return An error code
  */
-int caterva_resize(caterva_array_t *array,
+int caterva_resize(caterva_ctx_t *ctx, caterva_array_t *array,
                          int64_t *new_shape);
 
 #endif  // CATERVA_CATERVA_H_

--- a/tests/test_resize.c
+++ b/tests/test_resize.c
@@ -21,12 +21,12 @@ typedef struct {
 } test_shapes_t;
 
 
-CUTEST_TEST_DATA(extend_shape) {
+CUTEST_TEST_DATA(resize_shape) {
     caterva_ctx_t *ctx;
 };
 
 
-CUTEST_TEST_SETUP(extend_shape) {
+CUTEST_TEST_SETUP(resize_shape) {
     caterva_config_t cfg = CATERVA_CONFIG_DEFAULTS;
     cfg.nthreads = 2;
     cfg.compcodec = BLOSC_ZSTD;
@@ -49,25 +49,25 @@ CUTEST_TEST_SETUP(extend_shape) {
 
 
     CUTEST_PARAMETRIZE(shapes, test_shapes_t, CUTEST_DATA(
-            {1, {5}, {3}, {2}, {10}},
-            {2, {20, 5}, {7, 5}, {3, 3}, {20, 20}},
-            {2, {20, 10}, {7, 5}, {3, 5}, {30, 10}},
-            {2, {14, 10}, {8, 5}, {2, 2}, {20, 15}},
-            {3, {12, 10, 14}, {3, 5, 9}, {3, 4, 4}, {15, 18, 14}},
-            {3, {10, 21, 30}, {8, 7, 15}, {5, 5, 10}, {10, 40, 30}},
-            {2, {50, 50}, {25, 13}, {8, 8}, {50, 51}},
-            {2, {143, 41}, {18, 13}, {7, 7}, {145, 50}},
-            {4, {10, 10, 5, 5}, {5, 7, 3, 3}, {2, 2, 1, 1}, {10, 20, 5, 10}},
+            {1, {5}, {3}, {2}, {10}}, // extend only
+            {2, {20, 5}, {7, 5}, {3, 3}, {20, 20}}, // extend only
+            {2, {20, 10}, {7, 5}, {3, 5}, {10, 10}}, // shrink only
+            {2, {14, 10}, {8, 5}, {2, 2}, {10, 5}}, // shrink only
+            {3, {12, 10, 14}, {3, 5, 9}, {3, 4, 4}, {10, 15, 14}}, // shrink and extend
+            {3, {10, 21, 30}, {8, 7, 15}, {5, 5, 10}, {10, 13, 10}}, // shrink and extend
+            {2, {50, 50}, {25, 13}, {8, 8}, {49, 51}}, // shrink and extend
+            {2, {143, 41}, {18, 13}, {7, 7}, {50, 50}}, // shrink and extend
+            {4, {10, 10, 5, 5}, {5, 7, 3, 3}, {2, 2, 1, 1}, {11, 20, 2, 2}}, // shrink and extend
 
     ));
 }
 
-CUTEST_TEST_TEST(extend_shape) {
+CUTEST_TEST_TEST(resize_shape) {
     CUTEST_GET_PARAMETER(backend, _test_backend);
     CUTEST_GET_PARAMETER(shapes, test_shapes_t);
     CUTEST_GET_PARAMETER(itemsize, uint8_t);
 
-    char *urlpath = "test_extend_shape.b2frame";
+    char *urlpath = "test_resize_shape.b2frame";
     caterva_remove(data->ctx, urlpath);
 
     caterva_params_t params;
@@ -87,10 +87,28 @@ CUTEST_TEST_TEST(extend_shape) {
         storage.blockshape[i] = shapes.blockshape[i];
     }
 
-    /* Create dest buffer */
+    // Create dest buffer, get shrinked shape  and extended shape
     int64_t buffersize = itemsize;
+    int64_t shrink_shape[CATERVA_MAX_DIM] = {0};
+    int64_t shrink_size = itemsize;
+    int64_t extend_shape[CATERVA_MAX_DIM] = {0};
+    int64_t start_extend_slice[CATERVA_MAX_DIM] = {0};
+    int64_t extend_size = itemsize;
+    bool only_shrink = true;
     for (int i = 0; i < params.ndim; ++i) {
+        if (shapes.newshape[i] <= shapes.shape[i]) {
+            shrink_shape[i] = shapes.newshape[i];
+            extend_shape[i] = shapes.newshape[i];
+            start_extend_slice[i] = 0;
+        } else {
+            shrink_shape[i] = shapes.shape[i];
+            extend_shape[i] = (shapes.newshape[i]-shapes.shape[i]);
+            start_extend_slice[i] = shapes.shape[i];
+            only_shrink = false;
+        }
         buffersize *= shapes.shape[i];
+        shrink_size *= shrink_shape[i];
+        extend_size *= extend_shape[i];
     }
     uint8_t *buffer = data->ctx->cfg->alloc(buffersize);
     CUTEST_ASSERT("Buffer filled incorrectly", fill_buf(buffer, itemsize, buffersize / itemsize));
@@ -98,56 +116,91 @@ CUTEST_TEST_TEST(extend_shape) {
     caterva_array_t *src;
     CATERVA_ERROR(caterva_from_buffer(data->ctx, buffer, buffersize, &params, &storage, &src));
 
-    CATERVA_ERROR(caterva_resize(src, shapes.newshape));
+    // Get shrink slice previous to resize
+    uint8_t *original_buffer = data->ctx->cfg->alloc(shrink_size);
+    int64_t start_shape[CATERVA_MAX_DIM] = {0};
 
-    int64_t shape[CATERVA_MAX_DIM] = {0};
-    int64_t destsize = itemsize;
-    for (int i = 0; i < params.ndim; ++i) {
-        shape[i] = (shapes.newshape[i]-shapes.shape[i]);
-        destsize *= shape[i];
-    }
-    uint8_t *destbuffer = data->ctx->cfg->alloc((size_t) destsize);
-    /* Fill dest buffer with a slice from the new chunks*/
-   CATERVA_ERROR(caterva_get_slice_buffer(data->ctx, src, shapes.shape, shapes.newshape,
-                                                 destbuffer, shape,
-                                                 destsize));
+    CATERVA_ERROR(caterva_get_slice_buffer(data->ctx, src, start_shape, shrink_shape,
+                                           original_buffer, shrink_shape,
+                                           shrink_size));
 
-    for (uint64_t i = 0; i < (uint64_t) destsize / itemsize; ++i) {
+    CATERVA_ERROR(caterva_resize(data->ctx, src, shapes.newshape));
+
+
+    uint8_t *shrink_buffer = data->ctx->cfg->alloc((size_t) shrink_size);
+    /* Fill extend buffer with a slice from the new chunks*/
+    CATERVA_ERROR(caterva_get_slice_buffer(data->ctx, src, start_shape, shrink_shape,
+                                           shrink_buffer, shrink_shape,
+                                           shrink_size));
+    for (uint64_t i = 0; i < (uint64_t) shrink_size / itemsize; ++i) {
         switch (itemsize) {
             case 8:
                 CUTEST_ASSERT("Elements are not equal!",
-                           (uint64_t) 0 == ((uint64_t *) destbuffer)[i]);
+                              ((uint64_t *) original_buffer)[i] == ((uint64_t *) shrink_buffer)[i]);
                 break;
             case 4:
                 CUTEST_ASSERT("Elements are not equal!",
-                             (uint32_t) 0 == ((uint32_t *) destbuffer)[i]);
+                              ((uint32_t *) original_buffer)[i] == ((uint32_t *) shrink_buffer)[i]);
                 break;
             case 2:
                 CUTEST_ASSERT("Elements are not equal!",
-                              (uint16_t) 0 == ((uint16_t *) destbuffer)[i]);
+                              ((uint16_t *) original_buffer)[i] == ((uint16_t *) shrink_buffer)[i]);
                 break;
             case 1:
                 CUTEST_ASSERT("Elements are not equal!",
-                              (uint8_t) 0 == ((uint8_t *) destbuffer)[i]);
+                              ((uint8_t *) original_buffer)[i] == ((uint8_t *) shrink_buffer)[i]);
                 break;
             default:
                 CATERVA_TEST_ASSERT(CATERVA_ERR_INVALID_ARGUMENT);
         }
     }
 
+    if (!only_shrink) {
+        uint8_t *extend_buffer = data->ctx->cfg->alloc((size_t) extend_size);
+        /* Fill extend buffer with a slice from the new chunks*/
+        CATERVA_ERROR(caterva_get_slice_buffer(data->ctx, src, start_extend_slice, shapes.newshape,
+                                               extend_buffer, extend_shape,
+                                               extend_size));
+        for (uint64_t i = 0; i < (uint64_t) extend_size / itemsize; ++i) {
+            switch (itemsize) {
+                case 8:
+                    CUTEST_ASSERT("Elements are not equal!",
+                                  (uint64_t) 0 == ((uint64_t *) extend_buffer)[i]);
+                    break;
+                case 4:
+                    CUTEST_ASSERT("Elements are not equal!",
+                                  (uint32_t) 0 == ((uint32_t *) extend_buffer)[i]);
+                    break;
+                case 2:
+                    CUTEST_ASSERT("Elements are not equal!",
+                                  (uint16_t) 0 == ((uint16_t *) extend_buffer)[i]);
+                    break;
+                case 1:
+                    CUTEST_ASSERT("Elements are not equal!",
+                                  (uint8_t) 0 == ((uint8_t *) extend_buffer)[i]);
+                    break;
+                default:
+                    CATERVA_TEST_ASSERT(CATERVA_ERR_INVALID_ARGUMENT);
+            }
+        }
+        data->ctx->cfg->free(extend_buffer);
+    }
+
     /* Free mallocs */
     data->ctx->cfg->free(buffer);
-    data->ctx->cfg->free(destbuffer);
+    data->ctx->cfg->free(original_buffer);
+    data->ctx->cfg->free(shrink_buffer);
+
     CATERVA_TEST_ASSERT(caterva_free(data->ctx, &src));
     caterva_remove(data->ctx, urlpath);
 
     return 0;
 }
 
-CUTEST_TEST_TEARDOWN(extend_shape) {
+CUTEST_TEST_TEARDOWN(resize_shape) {
     caterva_ctx_free(&data->ctx);
 }
 
 int main() {
-    CUTEST_TEST_RUN(extend_shape);
+    CUTEST_TEST_RUN(resize_shape);
 }

--- a/tests/test_resize.c
+++ b/tests/test_resize.c
@@ -87,7 +87,7 @@ CUTEST_TEST_TEST(resize_shape) {
         storage.blockshape[i] = shapes.blockshape[i];
     }
 
-    // Create dest buffer, get shrinked shape  and extended shape
+    // Create dest buffer, get shrinked shape and extended shape
     int64_t buffersize = itemsize;
     int64_t shrink_shape[CATERVA_MAX_DIM] = {0};
     int64_t shrink_size = itemsize;
@@ -116,7 +116,7 @@ CUTEST_TEST_TEST(resize_shape) {
     caterva_array_t *src;
     CATERVA_ERROR(caterva_from_buffer(data->ctx, buffer, buffersize, &params, &storage, &src));
 
-    // Get shrink slice previous to resize
+    // Get original values in shrinked slice
     uint8_t *original_buffer = data->ctx->cfg->alloc(shrink_size);
     int64_t start_shape[CATERVA_MAX_DIM] = {0};
 


### PR DESCRIPTION
A new function to shrink an array was created.
As discussed in #99, the param `caterva_ctx_t *` was added to the function `caterva_resize`.