### PR TITLE
Fix warnings

### DIFF
--- a/bench/bench_zfp_getitem.c
+++ b/bench/bench_zfp_getitem.c
@@ -42,7 +42,7 @@ m_shape = precip_m0.shape
 m_chunks = (128, 128, 256)
 m_blocks = (32, 32, 32)
 cat_precip0 = cat.empty(m_shape, itemsize=4, chunks=m_chunks, blocks=m_blocks,
-                        urlpath="precip1.cat", sequential=True)
+                        urlpath="precip1.cat", contiguous=True)
 print("Fetching and storing 1st month...")
 values = precip_m0.values
 cat_precip0[:] = values

--- a/bench/bench_zfp_getitem.c
+++ b/bench/bench_zfp_getitem.c
@@ -72,16 +72,15 @@ int comp(const char* urlpath) {
     blosc2_remove_urlpath("schunk.cat");
 
     // Get multidimensional parameters and configure Caterva array
-    uint8_t ndim;
+    int8_t ndim;
     int32_t shape[4];
     int64_t *shape_aux = malloc(8 * sizeof(int64_t));
     int32_t *chunkshape = malloc(8 * sizeof(int32_t));
     int32_t *blockshape = malloc(8 * sizeof(int32_t));
     uint8_t *smeta;
-    uint32_t smeta_len;
+    int32_t smeta_len;
     if (blosc2_meta_get(schunk, "caterva", &smeta, &smeta_len) < 0) {
         printf("This benchmark only supports Caterva datasets");
-        free(shape);
         free(chunkshape);
         free(blockshape);
         return -1;
@@ -118,7 +117,6 @@ int comp(const char* urlpath) {
     copied = caterva_copy(ctx_zfp, arr, &storage, &arr_rate);
     if (copied != 0) {
         printf("Error BLOSC_CODEC_ZFP_FIXED_RATE \n");
-        free(shape);
         free(chunkshape);
         free(blockshape);
         caterva_free(ctx_zfp, &arr);
@@ -126,8 +124,9 @@ int comp(const char* urlpath) {
     }
     printf("ZFP_FIXED_RATE comp ratio: %f \n",(float) arr_rate->sc->nbytes / (float) arr_rate->sc->cbytes);
 
-    int nelems = arr_rate->nitems;
-    int index, dsize_zfp, dsize_blosc;
+    int64_t nelems = arr_rate->nitems;
+    int dsize_zfp, dsize_blosc;
+    int64_t index;
     float item_zfp, item_blosc;
     blosc_timestamp_t t0, t1;
     double zfp_time, blosc_time;
@@ -135,7 +134,8 @@ int comp(const char* urlpath) {
     int64_t index_ndim[ZFP_MAX_DIM];
     int64_t index_chunk_ndim[ZFP_MAX_DIM];
     int64_t ind_ndim[ZFP_MAX_DIM];
-    int stride_chunk, nchunk, ind_chunk;
+    int stride_chunk, ind_chunk;
+    int64_t nchunk;
     bool needs_free_blosc, needs_free_zfp;
     uint8_t *chunk_blosc, *chunk_zfp;
     int32_t chunk_nbytes_zfp, chunk_cbytes_zfp, chunk_nbytes_lossy, chunk_cbytes_lossy;
@@ -150,7 +150,7 @@ int comp(const char* urlpath) {
         }
         stride_chunk = (shape[1] - 1) / chunkshape[1] + 1;
         nchunk = index_chunk_ndim[0] * stride_chunk + index_chunk_ndim[1];
-        ind_chunk = ind_ndim[0] * chunkshape[1] + ind_ndim[1];
+        ind_chunk = (int32_t)(ind_ndim[0] * chunkshape[1] + ind_ndim[1]);
         blosc2_schunk_get_lazychunk(arr->sc, nchunk, &chunk_blosc, &needs_free_blosc);
         blosc2_cbuffer_sizes(chunk_blosc, &chunk_nbytes_lossy, &chunk_cbytes_lossy, NULL);
         blosc_set_timestamp(&t0);

--- a/caterva/caterva.c
+++ b/caterva/caterva.c
@@ -12,6 +12,7 @@
 #include <caterva.h>
 
 #include "caterva_utils.h"
+#include <inttypes.h>
 
 
 int caterva_ctx_new(caterva_config_t *cfg, caterva_ctx_t **ctx) {
@@ -1149,9 +1150,9 @@ int caterva_print_meta(caterva_array_t *array){
     free(smeta);
 
     printf("Caterva metalayer parameters: \n Ndim:       %d", ndim);
-    printf("\n Shape:      %lld", shape[0]);
+    printf("\n Shape:      %" PRId64 "", shape[0]);
     for (int i = 1; i < ndim; ++i) {
-        printf(", %lld", shape[i]);
+        printf(", %" PRId64 "", shape[i]);
     }
     printf("\n Chunkshape: %d", chunkshape[0]);
     for (int i = 1; i < ndim; ++i) {

--- a/caterva/caterva.c
+++ b/caterva/caterva.c
@@ -309,7 +309,7 @@ int caterva_from_schunk(caterva_ctx_t *ctx, blosc2_schunk *schunk, caterva_array
     params.itemsize = itemsize;
     caterva_storage_t storage = {0};
     storage.urlpath = schunk->storage->urlpath;
-    storage.sequencial = schunk->storage->contiguous;
+    storage.contiguous = schunk->storage->contiguous;
 
     // Deserialize the caterva metalayer
     uint8_t *smeta;
@@ -1009,7 +1009,7 @@ int caterva_save(caterva_ctx_t *ctx, caterva_array_t *array, char *urlpath) {
     caterva_array_t *tmp;
     caterva_storage_t storage;
     storage.urlpath = urlpath;
-    storage.sequencial = array->sc->storage->contiguous;
+    storage.contiguous = array->sc->storage->contiguous;
 
     for (int i = 0; i < array->ndim; ++i) {
         storage.chunkshape[i] = array->chunkshape[i];

--- a/caterva/caterva.c
+++ b/caterva/caterva.c
@@ -47,8 +47,8 @@ int caterva_ctx_free(caterva_ctx_t **ctx) {
 }
 
 // Only for internal use
-int caterva_update_shape(caterva_array_t *array, int8_t ndim, int64_t *shape,
-                               int32_t *chunkshape, int32_t *blockshape) {
+int caterva_update_shape(caterva_array_t *array, int8_t ndim, const int64_t *shape,
+                               const int32_t *chunkshape, const int32_t *blockshape) {
     array->ndim = ndim;
     array->nitems = 1;
     array->extnitems = 1;
@@ -791,8 +791,8 @@ int caterva_set_slice_buffer(caterva_ctx_t *ctx,
     return CATERVA_SUCCEED;
 }
 
-int caterva_get_slice(caterva_ctx_t *ctx, caterva_array_t *src, int64_t *start,
-                      int64_t *stop, caterva_storage_t *storage, caterva_array_t **array) {
+int caterva_get_slice(caterva_ctx_t *ctx, caterva_array_t *src, const int64_t *start,
+                      const int64_t *stop, caterva_storage_t *storage, caterva_array_t **array) {
     CATERVA_ERROR_NULL(ctx);
     CATERVA_ERROR_NULL(storage);
     CATERVA_ERROR_NULL(src);
@@ -814,7 +814,7 @@ int caterva_get_slice(caterva_ctx_t *ctx, caterva_array_t *src, int64_t *start,
         return CATERVA_SUCCEED;
     }
 
-    uint8_t ndim = (*array)->ndim;
+    int8_t ndim = (*array)->ndim;
     int64_t chunks_in_array[CATERVA_MAX_DIM] = {0};
     for (int i = 0; i < ndim; ++i) {
         chunks_in_array[i] = (*array)->extshape[i] / (*array)->chunkshape[i];
@@ -876,7 +876,7 @@ int caterva_squeeze(caterva_ctx_t *ctx, caterva_array_t *array) {
     return CATERVA_SUCCEED;
 }
 
-int caterva_squeeze_index(caterva_ctx_t *ctx, caterva_array_t *array, bool *index) {
+int caterva_squeeze_index(caterva_ctx_t *ctx, caterva_array_t *array, const bool *index) {
     CATERVA_ERROR_NULL(ctx);
     CATERVA_ERROR_NULL(array);
 
@@ -1136,7 +1136,7 @@ int caterva_meta_exists(caterva_ctx_t *ctx, caterva_array_t *array,
 
 int caterva_print_meta(caterva_array_t *array){
     CATERVA_ERROR_NULL(array);
-    uint8_t ndim;
+    int8_t ndim;
     int64_t shape[8];
     int32_t chunkshape[8];
     int32_t blockshape[8];
@@ -1150,9 +1150,9 @@ int caterva_print_meta(caterva_array_t *array){
     free(smeta);
 
     printf("Caterva metalayer parameters: \n Ndim:       %d", ndim);
-    printf("\n Shape:      %ld", shape[0]);
+    printf("\n Shape:      %lld", shape[0]);
     for (int i = 1; i < ndim; ++i) {
-        printf(", %ld", shape[i]);
+        printf(", %lld", shape[i]);
     }
     printf("\n Chunkshape: %d", chunkshape[0]);
     for (int i = 1; i < ndim; ++i) {
@@ -1188,7 +1188,7 @@ int extend_shape(caterva_array_t *array, int64_t *new_shape) {
     CATERVA_ERROR_NULL(array);
     CATERVA_ERROR_NULL(new_shape);
 
-    uint8_t ndim = array->ndim;
+    int8_t ndim = array->ndim;
     int64_t diffs_shape[CATERVA_MAX_DIM];
     int64_t diffs_sum = 0;
     for (int i = 0; i < ndim; i++) {

--- a/caterva/caterva.h
+++ b/caterva/caterva.h
@@ -206,7 +206,7 @@ typedef struct {
     //!< The size of each item of the array.
     int64_t shape[CATERVA_MAX_DIM];
     //!< The array shape.
-    uint8_t ndim;
+    int8_t ndim;
     //!< The array dimensions.
 } caterva_params_t;
 
@@ -251,7 +251,7 @@ typedef struct {
     //!< Number of items in each block.
     int64_t extchunknitems;
     //!< Number of items in a padded chunk.
-    uint8_t ndim;
+    int8_t ndim;
     //!< Data dimensions.
     uint8_t itemsize;
     //!< Size of each item.
@@ -451,8 +451,8 @@ int caterva_to_buffer(caterva_ctx_t *ctx, caterva_array_t *array, void *buffer,
  *
  * @return An error code.
  */
-int caterva_get_slice(caterva_ctx_t *ctx, caterva_array_t *src, int64_t *start,
-                      int64_t *stop, caterva_storage_t *storage, caterva_array_t **array);
+int caterva_get_slice(caterva_ctx_t *ctx, caterva_array_t *src, const int64_t *start,
+                      const int64_t *stop, caterva_storage_t *storage, caterva_array_t **array);
 
 /**
  * @brief Squeeze a caterva array
@@ -467,7 +467,7 @@ int caterva_get_slice(caterva_ctx_t *ctx, caterva_array_t *src, int64_t *start,
  * @return An error code
  */
 int caterva_squeeze_index(caterva_ctx_t *ctx, caterva_array_t *array,
-                          bool *index);
+                          const bool *index);
 
 /**
  * @brief Squeeze a caterva array

--- a/caterva/caterva.h
+++ b/caterva/caterva.h
@@ -187,8 +187,8 @@ typedef struct {
     //!< The shape of each chunk of Blosc.
     int32_t blockshape[CATERVA_MAX_DIM];
     //!< The shape of each block of Blosc.
-    bool sequencial;
-    //!< Flag to indicate if the super-chunk is stored sequentially or sparsely.
+    bool contiguous;
+    //!< Flag to indicate if the super-chunk is stored contiguously or sparsely.
     char *urlpath;
     //!< The super-chunk name. If @p urlpath is not @p NULL, the super-chunk will be stored on
     //!< disk.

--- a/caterva/caterva_utils.c
+++ b/caterva/caterva_utils.c
@@ -129,13 +129,13 @@ int32_t deserialize_meta(uint8_t *smeta, uint32_t smeta_len, int8_t *ndim, int64
     pmeta += 1;
 
     // version entry
-    int8_t version = pmeta[0];  // positive fixnum (7-bit positive integer)
+    int8_t version = (int8_t)pmeta[0];  // positive fixnum (7-bit positive integer)
     CATERVA_UNUSED_PARAM(version);
 
     pmeta += 1;
 
     // ndim entry
-    *ndim = pmeta[0];
+    *ndim = (int8_t)pmeta[0];
     int8_t ndim_aux = *ndim;  // positive fixnum (7-bit positive integer)
     pmeta += 1;
 
@@ -354,15 +354,15 @@ void copy_ndim_fallback(const int8_t ndim,
     for (int ncopy = 0; ncopy < number_of_copies; ++ncopy) {
         // Compute the start of the copy
         int64_t copy_start[CATERVA_MAX_DIM] = {0};
-        index_unidim_to_multidim(ndim - 1, copy_shape, ncopy, copy_start);
+        index_unidim_to_multidim((int8_t)(ndim -1), copy_shape, ncopy, copy_start);
 
         // Translate this index to the src buffer
         int64_t src_copy_start;
-        index_multidim_to_unidim(copy_start, ndim - 1, src_strides, &src_copy_start);
+        index_multidim_to_unidim(copy_start, (int8_t)(ndim - 1), src_strides, &src_copy_start);
 
         // Translate this index to the dst buffer
         int64_t dst_copy_start;
-        index_multidim_to_unidim(copy_start, ndim - 1, dst_strides, &dst_copy_start);
+        index_multidim_to_unidim(copy_start, (int8_t)(ndim - 1), dst_strides, &dst_copy_start);
 
         // Perform the copy
         memcpy(&bdst[dst_copy_start * itemsize],

--- a/caterva/caterva_utils.c
+++ b/caterva/caterva_utils.c
@@ -482,7 +482,7 @@ int create_blosc_params(caterva_ctx_t *ctx,
     b_storage->cparams = cparams;
     b_storage->dparams = dparams;
 
-    if (storage->sequencial) {
+    if (storage->contiguous) {
         b_storage->contiguous = true;
     }
     if (storage->urlpath != NULL) {

--- a/caterva/caterva_utils.c
+++ b/caterva/caterva_utils.c
@@ -10,7 +10,7 @@
  */
 #include <caterva_utils.h>
 
-void index_unidim_to_multidim(int8_t ndim, int64_t *shape, int64_t i, int64_t *index) {
+void index_unidim_to_multidim(int8_t ndim, const int64_t *shape, int64_t i, int64_t *index) {
     int64_t strides[CATERVA_MAX_DIM];
     if (ndim == 0) {
         return;
@@ -26,7 +26,7 @@ void index_unidim_to_multidim(int8_t ndim, int64_t *shape, int64_t i, int64_t *i
     }
 }
 
-void index_multidim_to_unidim(int64_t *index, int8_t ndim, int64_t *strides, int64_t *i) {
+void index_multidim_to_unidim(const int64_t *index, int8_t ndim, const int64_t *strides, int64_t *i) {
     *i = 0;
     for (int j = 0; j < ndim; ++j) {
         *i += index[j] * strides[j];
@@ -74,11 +74,11 @@ void swap_store(void *dest, const void *pa, int size) {
     free(pa2_);
 }
 
-int32_t serialize_meta(uint8_t ndim, int64_t *shape, const int32_t *chunkshape,
+int32_t serialize_meta(int8_t ndim, int64_t *shape, const int32_t *chunkshape,
                               const int32_t *blockshape, uint8_t **smeta) {
     // Allocate space for Caterva metalayer
-    int32_t max_smeta_len = 1 + 1 + 1 + (1 + ndim * (1 + sizeof(int64_t))) +
-                            (1 + ndim * (1 + sizeof(int32_t))) + (1 + ndim * (1 + sizeof(int32_t)));
+    int32_t max_smeta_len = (int32_t) (1 + 1 + 1 + (1 + ndim * (1 + sizeof(int64_t))) +
+                            (1 + ndim * (1 + sizeof(int32_t))) + (1 + ndim * (1 + sizeof(int32_t))));
     *smeta = malloc((size_t) max_smeta_len);
     CATERVA_ERROR_NULL(smeta);
     uint8_t *pmeta = *smeta;
@@ -120,7 +120,7 @@ int32_t serialize_meta(uint8_t ndim, int64_t *shape, const int32_t *chunkshape,
     return slen;
 }
 
-int32_t deserialize_meta(uint8_t *smeta, uint32_t smeta_len, uint8_t *ndim, int64_t *shape,
+int32_t deserialize_meta(uint8_t *smeta, uint32_t smeta_len, int8_t *ndim, int64_t *shape,
                                 int32_t *chunkshape, int32_t *blockshape) {
     uint8_t *pmeta = smeta;
     CATERVA_UNUSED_PARAM(smeta_len);
@@ -341,7 +341,7 @@ void copy2dim(const uint8_t itemsize,
 }
 
 
-void copy_ndim_fallback(const uint8_t ndim,
+void copy_ndim_fallback(const int8_t ndim,
                         const uint8_t itemsize,
                         int64_t* copy_shape,
                         const uint8_t *bsrc, int64_t* src_strides,
@@ -371,11 +371,11 @@ void copy_ndim_fallback(const uint8_t ndim,
     }
 }
 
-int caterva_copy_buffer(uint8_t ndim,
+int caterva_copy_buffer(int8_t ndim,
                         uint8_t itemsize,
-                        void *src, int64_t *src_pad_shape,
-                        int64_t *src_start, int64_t *src_stop,
-                        void *dst, int64_t *dst_pad_shape,
+                        void *src, const int64_t *src_pad_shape,
+                        int64_t *src_start, const int64_t *src_stop,
+                        void *dst, const int64_t *dst_pad_shape,
                         int64_t *dst_start) {
     // Compute the shape of the copy
     int64_t copy_shape[CATERVA_MAX_DIM] = {0};

--- a/caterva/caterva_utils.h
+++ b/caterva/caterva_utils.h
@@ -18,21 +18,21 @@
 extern "C" {
 #endif
 
-void index_unidim_to_multidim(int8_t ndim, int64_t *shape, int64_t i, int64_t *index);
-void index_multidim_to_unidim(int64_t *index, int8_t ndim, int64_t *strides, int64_t *i);
+void index_unidim_to_multidim(int8_t ndim, const int64_t *shape, int64_t i, int64_t *index);
+void index_multidim_to_unidim(const int64_t *index, int8_t ndim, const int64_t *strides, int64_t *i);
 
-int32_t serialize_meta(uint8_t ndim, int64_t *shape, const int32_t *chunkshape,
+int32_t serialize_meta(int8_t ndim, int64_t *shape, const int32_t *chunkshape,
                        const int32_t *blockshape, uint8_t **smeta);
-int32_t deserialize_meta(uint8_t *smeta, uint32_t smeta_len, uint8_t *ndim, int64_t *shape,
+int32_t deserialize_meta(uint8_t *smeta, uint32_t smeta_len, int8_t *ndim, int64_t *shape,
                          int32_t *chunkshape, int32_t *blockshape);
 
 void swap_store(void *dest, const void *pa, int size);
 
-int caterva_copy_buffer(uint8_t ndim,
+int caterva_copy_buffer(int8_t ndim,
                         uint8_t itemsize,
-                        void *src, int64_t *src_pad_shape,
-                        int64_t *src_start, int64_t *src_stop,
-                        void *dst, int64_t *dst_pad_shape,
+                        void *src, const int64_t *src_pad_shape,
+                        int64_t *src_start, const int64_t *src_stop,
+                        void *dst, const int64_t *dst_pad_shape,
                         int64_t *dst_start);
 
 int create_blosc_params(caterva_ctx_t *ctx,

--- a/examples/example_frame_generator.c
+++ b/examples/example_frame_generator.c
@@ -12,8 +12,8 @@
 # include <stdlib.h>
 
 
-int frame_generator(int8_t *data, int8_t ndim, int64_t shape[8], int32_t chunkshape[8],
-                    int32_t blockshape[8], int8_t itemsize, int64_t size, char *urlpath) {
+int frame_generator(int8_t *data, int8_t ndim, const int64_t shape[8], const int32_t chunkshape[8],
+                    const int32_t blockshape[8], int8_t itemsize, int64_t size, char *urlpath) {
 
     caterva_config_t cfg = CATERVA_CONFIG_DEFAULTS;
     caterva_ctx_t *ctx;
@@ -28,7 +28,7 @@ int frame_generator(int8_t *data, int8_t ndim, int64_t shape[8], int32_t chunksh
 
     caterva_storage_t storage = {0};
     storage.urlpath = urlpath;
-    storage.sequencial = true;
+    storage.contiguous = true;
     for (int i = 0; i < ndim; ++i) {
         storage.chunkshape[i] = chunkshape[i];
         storage.blockshape[i] = blockshape[i];

--- a/examples/example_frame_generator.c
+++ b/examples/example_frame_generator.c
@@ -127,7 +127,7 @@ int float_cyclic() {
        data[i + 1] = (2 + j / 10 + j / 1000);
     }
     char *urlpath = "example_float_cyclic.caterva";
-    CATERVA_ERROR(frame_generator(data, ndim, shape, chunkshape, blockshape, itemsize, size, urlpath));
+    CATERVA_ERROR(frame_generator((int8_t *)data, ndim, shape, chunkshape, blockshape, itemsize, size, urlpath));
 
     return 0;
 }
@@ -152,7 +152,7 @@ int double_same_cells() {
        data[i + 3] = 3.2;
     }
     char *urlpath = "example_double_same_cells.caterva";
-    CATERVA_ERROR(frame_generator(data, ndim, shape, chunkshape, blockshape, itemsize, size, urlpath));
+    CATERVA_ERROR(frame_generator((int8_t *)data, ndim, shape, chunkshape, blockshape, itemsize, size, urlpath));
 
     return 0;
 }
@@ -178,7 +178,7 @@ int big_float_frame() {
        data[i + 3] = (11 + j / 100 - j / 1000);
     }
     char *urlpath = "example_big_float_frame.caterva";
-    CATERVA_ERROR(frame_generator(data, ndim, shape, chunkshape, blockshape, itemsize, size, urlpath));
+    CATERVA_ERROR(frame_generator((int8_t *)data, ndim, shape, chunkshape, blockshape, itemsize, size, urlpath));
 
     return 0;
 }
@@ -206,7 +206,7 @@ int day_month_temp() {
        i += 3;
     }
     char *urlpath = "example_day_month_temp.caterva";
-    CATERVA_ERROR(frame_generator(data, ndim, shape, chunkshape, blockshape, itemsize, size, urlpath));
+    CATERVA_ERROR(frame_generator((int8_t *)data, ndim, shape, chunkshape, blockshape, itemsize, size, urlpath));
 
     return 0;
 }
@@ -238,7 +238,7 @@ int item_prices() {
        }
     }
     char *urlpath = "example_item_prices.caterva";
-    CATERVA_ERROR(frame_generator(data, ndim, shape, chunkshape, blockshape, itemsize, size, urlpath));
+    CATERVA_ERROR(frame_generator((int8_t *)data, ndim, shape, chunkshape, blockshape, itemsize, size, urlpath));
 
     return 0;
 }

--- a/examples/example_plugins_codecs.c
+++ b/examples/example_plugins_codecs.c
@@ -27,6 +27,7 @@
 #include <stdio.h>
 #include <blosc2.h>
 #include "../contribs/c-blosc2/plugins/codecs/codecs-registry.c"
+#include <inttypes.h>
 
 int main() {
     blosc_timestamp_t t0, t1;
@@ -96,7 +97,7 @@ int main() {
     for (int i = 0; i < buffer_size / itemsize; i++) {
         if (src[i] != buffer[i]) {
             printf("\n Decompressed data differs from original!\n");
-            printf("i: %d, data %lld, dest %lld", i, src[i], buffer[i]);
+            printf("i: %d, data %" PRId64 ", dest %" PRId64 "", i, src[i], buffer[i]);
             return -1;
         }
     }

--- a/examples/example_plugins_filters.c
+++ b/examples/example_plugins_filters.c
@@ -27,6 +27,7 @@
 #include <stdio.h>
 #include <blosc2.h>
 #include "../contribs/c-blosc2/plugins/filters/filters-registry.c"
+#include <inttypes.h>
 
 int main() {
     blosc_timestamp_t t0, t1;
@@ -94,7 +95,7 @@ int main() {
     for (int i = 0; i < buffer_size / itemsize; i++) {
         if (src[i] != buffer[i]) {
             printf("\n Decompressed data differs from original!\n");
-            printf("i: %d, data %lld, dest %lld", i, src[i], buffer[i]);
+            printf("i: %d, data %" PRId64 ", dest %" PRId64 "", i, src[i], buffer[i]);
             return -1;
         }
     }

--- a/tests/test_common.h
+++ b/tests/test_common.h
@@ -65,7 +65,7 @@ typedef struct {
 
 
 typedef struct {
-    bool sequential;
+    bool contiguous;
     bool persistent;
 } _test_backend;
 

--- a/tests/test_copy.c
+++ b/tests/test_copy.c
@@ -95,7 +95,7 @@ CUTEST_TEST_TEST(copy) {
     } else {
         storage.urlpath = NULL;
     }
-    storage.sequencial = backend.sequential;
+    storage.contiguous = backend.contiguous;
     for (int i = 0; i < params.ndim; ++i) {
         storage.chunkshape[i] = shapes.chunkshape[i];
         storage.blockshape[i] = shapes.blockshape[i];
@@ -145,7 +145,7 @@ CUTEST_TEST_TEST(copy) {
     } else {
         storage2.urlpath = NULL;
     }
-    storage2.sequencial = backend2.sequential;
+    storage2.contiguous = backend2.contiguous;
     for (int i = 0; i < shapes.ndim; ++i) {
         storage2.chunkshape[i] = shapes.chunkshape2[i];
         storage2.blockshape[i] = shapes.blockshape2[i];

--- a/tests/test_full.c
+++ b/tests/test_full.c
@@ -69,7 +69,7 @@ CUTEST_TEST_TEST(full) {
     if (backend.persistent) {
         storage.urlpath = urlpath;
     }
-    storage.sequencial = backend.sequential;
+    storage.contiguous = backend.contiguous;
     for (int i = 0; i < shapes.ndim; ++i) {
         storage.chunkshape[i] = shapes.chunkshape[i];
         storage.blockshape[i] = shapes.blockshape[i];

--- a/tests/test_get_slice.c
+++ b/tests/test_get_slice.c
@@ -101,7 +101,7 @@ CUTEST_TEST_TEST(get_slice) {
     if (backend.persistent) {
         storage.urlpath = urlpath;
     }
-    storage.sequencial = backend.sequential;
+    storage.contiguous = backend.contiguous;
     for (int i = 0; i < params.ndim; ++i) {
         storage.chunkshape[i] = shapes.chunkshape[i];
         storage.blockshape[i] = shapes.blockshape[i];
@@ -136,7 +136,7 @@ CUTEST_TEST_TEST(get_slice) {
     if (backend2.persistent) {
         storage2.urlpath = urlpath2;
     }
-    storage2.sequencial = backend2.sequential;
+    storage2.contiguous = backend2.contiguous;
     for (int i = 0; i < params.ndim; ++i) {
         storage2.chunkshape[i] = shapes.chunkshape2[i];
         storage2.blockshape[i] = shapes.blockshape2[i];

--- a/tests/test_get_slice_buffer.c
+++ b/tests/test_get_slice_buffer.c
@@ -93,7 +93,7 @@ CUTEST_TEST_TEST(get_slice_buffer) {
     if (backend.persistent) {
         storage.urlpath = urlpath;
     }
-    storage.sequencial = backend.sequential;
+    storage.contiguous = backend.contiguous;
     for (int i = 0; i < params.ndim; ++i) {
         storage.chunkshape[i] = shapes.chunkshape[i];
         storage.blockshape[i] = shapes.blockshape[i];

--- a/tests/test_metalayers.c
+++ b/tests/test_metalayers.c
@@ -55,7 +55,7 @@ CUTEST_TEST_TEST(metalayers) {
     if (backend.persistent) {
         storage.urlpath = urlpath;
     }
-    storage.sequencial = backend.sequential;
+    storage.contiguous = backend.contiguous;
     for (int i = 0; i < params.ndim; ++i) {
         storage.chunkshape[i] = shapes.chunkshape[i];
         storage.blockshape[i] = shapes.blockshape[i];

--- a/tests/test_persistency.c
+++ b/tests/test_persistency.c
@@ -76,7 +76,7 @@ CUTEST_TEST_TEST(persistency) {
     if (backend.persistent) {
         storage.urlpath = urlpath;
     }
-    storage.sequencial = backend.sequential;
+    storage.contiguous = backend.contiguous;
     for (int i = 0; i < params.ndim; ++i) {
         storage.chunkshape[i] = shapes.chunkshape[i];
         storage.blockshape[i] = shapes.blockshape[i];

--- a/tests/test_resize.c
+++ b/tests/test_resize.c
@@ -81,7 +81,7 @@ CUTEST_TEST_TEST(resize_shape) {
     if (backend.persistent) {
         storage.urlpath = urlpath;
     }
-    storage.sequencial = backend.sequential;
+    storage.contiguous = backend.contiguous;
     for (int i = 0; i < params.ndim; ++i) {
         storage.chunkshape[i] = shapes.chunkshape[i];
         storage.blockshape[i] = shapes.blockshape[i];

--- a/tests/test_roundtrip.c
+++ b/tests/test_roundtrip.c
@@ -47,7 +47,7 @@ CUTEST_TEST_TEST(roundtrip) {
     if (backend.persistent) {
         storage.urlpath = urlpath;
     }
-    storage.sequencial = backend.sequential;
+    storage.contiguous = backend.contiguous;
     for (int i = 0; i < shapes.ndim; ++i) {
         storage.chunkshape[i] = shapes.chunkshape[i];
         storage.blockshape[i] = shapes.blockshape[i];

--- a/tests/test_save.c
+++ b/tests/test_save.c
@@ -71,7 +71,7 @@ CUTEST_TEST_TEST(save) {
 
     caterva_storage_t storage = {0};
     storage.urlpath = NULL;
-    storage.sequencial = backend.sequential;
+    storage.contiguous = backend.contiguous;
     for (int i = 0; i < params.ndim; ++i) {
         storage.chunkshape[i] = shapes.chunkshape[i];
         storage.blockshape[i] = shapes.blockshape[i];

--- a/tests/test_serialize.c
+++ b/tests/test_serialize.c
@@ -51,7 +51,7 @@ CUTEST_TEST_TEST(serialize) {
 
     caterva_storage_t storage = {0};
     storage.urlpath = NULL;
-    storage.sequencial = true;
+    storage.contiguous = true;
     for (int i = 0; i < params.ndim; ++i) {
         storage.chunkshape[i] = shapes.chunkshape[i];
         storage.blockshape[i] = shapes.blockshape[i];

--- a/tests/test_set_slice_buffer.c
+++ b/tests/test_set_slice_buffer.c
@@ -83,7 +83,7 @@ CUTEST_TEST_TEST(set_slice_buffer) {
     if (backend.persistent) {
         storage.urlpath = urlpath;
     }
-    storage.sequencial = backend.sequential;
+    storage.contiguous = backend.contiguous;
     for (int i = 0; i < params.ndim; ++i) {
         storage.chunkshape[i] = shapes.chunkshape[i];
         storage.blockshape[i] = shapes.blockshape[i];

--- a/tests/test_squeeze.c
+++ b/tests/test_squeeze.c
@@ -89,7 +89,7 @@ CUTEST_TEST_TEST(squeeze) {
     if (backend.persistent) {
         storage.urlpath = urlpath;
     }
-    storage.sequencial = backend.sequential;
+    storage.contiguous = backend.contiguous;
     for (int i = 0; i < params.ndim; ++i) {
         storage.chunkshape[i] = shapes.chunkshape[i];
         storage.blockshape[i] = shapes.blockshape[i];
@@ -115,7 +115,7 @@ CUTEST_TEST_TEST(squeeze) {
     if (backend2.persistent) {
         storage2.urlpath = urlpath2;
     }
-    storage2.sequencial = backend2.sequential;
+    storage2.contiguous = backend2.contiguous;
     for (int i = 0; i < params.ndim; ++i) {
         storage2.chunkshape[i] = shapes.chunkshape2[i];
         storage2.blockshape[i] = shapes.blockshape2[i];

--- a/tests/test_squeeze_index.c
+++ b/tests/test_squeeze_index.c
@@ -98,7 +98,7 @@ CUTEST_TEST_TEST(squeeze_index) {
         if (backend.persistent) {
             storage.urlpath = urlpath;
         }
-        storage.sequencial = backend.persistent;
+        storage.contiguous = backend.persistent;
         for (int i = 0; i < params.ndim; ++i) {
             storage.chunkshape[i] = shapes.chunkshape[i];
             storage.blockshape[i] = shapes.blockshape[i];
@@ -124,7 +124,7 @@ CUTEST_TEST_TEST(squeeze_index) {
     if (backend2.persistent) {
         storage2.urlpath = urlpath2;
     }
-    storage2.sequencial = backend2.sequential;
+    storage2.contiguous = backend2.contiguous;
     for (int i = 0; i < params.ndim; ++i) {
         storage2.chunkshape[i] = shapes.chunkshape2[i];
         storage2.blockshape[i] = shapes.blockshape2[i];

--- a/tests/test_zeros.c
+++ b/tests/test_zeros.c
@@ -64,7 +64,7 @@ CUTEST_TEST_TEST(zeros) {
     if (backend.persistent) {
         storage.urlpath = urlpath;
     }
-    storage.sequencial = backend.sequential;
+    storage.contiguous = backend.contiguous;
     for (int i = 0; i < shapes.ndim; ++i) {
         storage.chunkshape[i] = shapes.chunkshape[i];
         storage.blockshape[i] = shapes.blockshape[i];


### PR DESCRIPTION
- Change sequential to contiguous. Fixes #89.
- Change caterva_array->ndim type from uint8_t to int8_t.
- Update submodule 
- Fix warnings